### PR TITLE
build fixes for NetBSD.

### DIFF
--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,11 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 BASEDIR="$PWD"
 
 if [ ! -d cherly ]; then
 	git clone https://github.com/leo-project/cherly.git 
 fi
-(cd cherly && ./configure && make)
+
+# for some systems including NetBSD, GNU make is commonly installed as "gmake".
+MAKE=make
+if type gmake > /dev/null; then
+	MAKE=gmake
+fi
+
+(cd cherly && ./configure && ${MAKE})
 if [ $? -ne 0 ]; then
 	echo "you probably need to do 'cd cherly; sudo make install' manually."
 fi


### PR DESCRIPTION
- remove an unnecessary bash dependency.
- use "gmake" if available.  cherly excepts GNU make.
