### PR TITLE
modify version number strings same as the other components config files

### DIFF
--- a/priv/leo_gateway.conf
+++ b/priv/leo_gateway.conf
@@ -1,5 +1,5 @@
 ##======================================================================
-## LeoFS - Gateway Configuration v1.1.0
+## LeoFS - Gateway Configuration
 ##
 ## See: http://leo-project.net/leofs/docs/configuration/configuration_3.html
 ##======================================================================
@@ -62,13 +62,13 @@ http.max_keepalive = 4096
 ## http.layer_of_dirs = 12
 
 ## Port number the Gateway uses for HTTPS connections
-## http.ssl_port     = 8443
+## http.ssl_port = 8443
 
 ## SSL Certificate file
 ## http.ssl_certfile = ./etc/server_cert.pem
 
 ## SSL key
-## http.ssl_keyfile  = ./etc/server_key.pem
+## http.ssl_keyfile = ./etc/server_key.pem
 
 ## HTTP custom header configuration file path
 ## http.headers_config_file = ./etc/http_custom_header.conf
@@ -129,7 +129,7 @@ large_object.reading_chunked_obj_len = 5242880
 ## cache.cache_workers = 16
 
 ## Memory cache capacity in bytes
-cache.cache_ram_capacity  = 268435456
+cache.cache_ram_capacity = 268435456
 
 ## Disk cache capacity in bytes
 cache.cache_disc_capacity = 524288000
@@ -138,7 +138,7 @@ cache.cache_disc_capacity = 524288000
 cache.cache_disc_threshold_len = 1048576
 
 ## Directory for the disk cache data
-cache.cache_disc_dir_data    = ./cache/data
+cache.cache_disc_dir_data = ./cache/data
 
 ## Directory for the disk cache journal
 cache.cache_disc_dir_journal = ./cache/journal
@@ -214,10 +214,10 @@ watchdog.rex.threshold_mem_capacity = 33554432
 ## --------------------------------------------------------------------
 ## Timeout value when requesting to a storage
 ## 0 to 65,535 bytes
-## timeout.level_1 =  5000
+## timeout.level_1 = 5000
 
 ## 65,535 to 131,071 bytes
-## timeout.level_2 =  7000
+## timeout.level_2 = 7000
 
 ## 131,072 to 524,287 bytes
 ## timeout.level_3 = 10000
@@ -261,7 +261,7 @@ watchdog.rex.threshold_mem_capacity = 33554432
 ## GATEWAY - Other Directories
 ## --------------------------------------------------------------------
 ## Directory of queue for monitoring "RING"
-## queue_dir  = ./work/queue
+## queue_dir = ./work/queue
 
 ## Directory of SNMP agent configuration
 ## snmp_agent = ./snmp/snmpa_gateway_0/LEO-GATEWAY


### PR DESCRIPTION
leo_gateway.conf has version number in comment-out part. I modified it same style like leo_storage and leo_manager.
And also, it has 2 or more space strings in some part of configuration values. I changed it to use 1 space string. 