### PR TITLE
Handle get_object with range

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,7 +34,7 @@
         {savanna_agent,         ".*", {git, "https://github.com/leo-project/savanna_agent.git",         {tag, "0.4.8"}}},
         {erpcgen,               ".*", {git, "https://github.com/leo-project/erpcgen.git",               {tag, "0.2.3"}}},
         {nfs_rpc_server,        ".*", {git, "https://github.com/leo-project/nfs_rpc_server.git",        {tag, "0.2.3"}}},
-        {cowboy,                ".*", {git, "https://github.com/ninenines/cowboy.git",                  {tag, "1.0.0"}}},
+        {cowboy,                ".*", {git, "https://github.com/leo-project/cowboy.git",                {branch, "feature/fix-issue-376"}}},
         {cowlib,                ".*", {git, "https://github.com/ninenines/cowlib.git",                  {tag, "1.0.0"}}},
         {meck,                  ".*", {git, "https://github.com/eproxus/meck.git",                      {tag, "0.8.2"}}},
         {proper,                ".*", {git, "https://github.com/manopapad/proper.git", "7d535ac61e9c2a9a7616af4615c39595a3c5739f"}}

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -753,8 +753,12 @@ get_range_object(Req, Bucket, Key, {_Unit, Range}) when is_list(Range) ->
             ?reply_bad_range([?SERVER_HEADER], Key, <<>>, Req);
         {error, unavailable} ->
             ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
+        {error, timeout} ->
+            ?reply_timeout_without_body([?SERVER_HEADER], Req);
+        {error, ?ERR_TYPE_INTERNAL_ERROR} ->
+            ?reply_internal_error_without_body([?SERVER_HEADER], Req);
         _ ->
-            ?reply_not_found([?SERVER_HEADER], Key, <<>>, Req)
+            ?reply_not_found_without_body([?SERVER_HEADER], Req)
     end.
 
 get_body_length_1(Key, Range) ->
@@ -780,9 +784,18 @@ get_body_length([End|Rest], ObjectSize, Acc) when End < ObjectSize ->
 get_body_length(_, _, _) ->
     {error, bad_range}.
 
+get_range_object_1(_Req, _Bucket, _Key, _, {error, _Reason}, Socket, Transport) ->
+    Transport:close(Socket);
+%    Transport:close(Socket),
+%    case Reason of
+%        unavailable ->
+%            ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
+%        not_found ->
+%            ?reply_not_found([?SERVER_HEADER], Key, <<>>, Req);
+%        _ ->
+%            ?reply_internal_error_without_body([?SERVER_HEADER], Req)
+%    end;
 get_range_object_1(Req,_Bucket,_Key, [], _, _Socket, _Transport) ->
-    {ok, Req};
-get_range_object_1(Req,_Bucket,_Key, _, {error, _}, _Socket, _Transport) ->
     {ok, Req};
 get_range_object_1(Req, Bucket, Key, [{Start, infinity}|Rest], _, Socket, Transport) ->
     Ret = get_range_object_2(Req, Bucket, Key, Start, 0, Socket, Transport),
@@ -823,25 +836,26 @@ get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport) ->
             get_range_object_large(Req, Bucket, Key,
                                    NewStartPos, NewEndPos, N, Index_1, CurPos_1,
                                    Socket, Transport);
-        {error, unavailable} ->
-            ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
-        _ ->
-            {error, not_found}
+        Error ->
+            Error
     end.
 
 
 %% @doc Retrieve the small object
 %% @private
-get_range_object_small(Req, Bucket, Key, Start, End, Socket, Transport) ->
+get_range_object_small(_Req, Bucket, Key, Start, End, Socket, Transport) ->
     case leo_gateway_rpc_handler:get(Key, Start, End) of
         {ok, _Meta, <<>>} ->
             ?access_log_get(Bucket, Key, 0, ?HTTP_ST_OK),
             ok;
         {ok, _Meta, Bin} ->
             ?access_log_get(Bucket, Key, byte_size(Bin), ?HTTP_ST_OK),
-            Transport:send(Socket, Bin);
-        {error, unavailable} ->
-            ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
+            case Transport:send(Socket, Bin) of
+                ok ->
+                    ok;
+                {error, Cause} ->
+                    {error, Cause}
+            end;
         {error, Cause} ->
             {error, Cause}
     end.
@@ -868,6 +882,8 @@ calc_pos(StartPos, EndPos, _ObjectSize) ->
 
 %% @doc Retrieve the large object
 %% @private
+get_range_object_large(_Req,_Bucket,_Key,_Start,_End, _Total, _Index, {error, _} = Error, _Socket, _Transport) ->
+    Error;
 get_range_object_large(_Req,_Bucket,_Key,_Start,_End, Total, Total, CurPos, _Socket, _Transport) ->
     {ok, CurPos};
 get_range_object_large(_Req,_Bucket,_Key,_Start, End,_Total,_Index, CurPos, _Socket, _Transport) when CurPos > End ->
@@ -890,8 +906,6 @@ get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos, Sock
                 {error, Cause} ->
                     {error, Cause}
             end;
-        {error, unavailable} ->
-            ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
         {error, Cause} ->
             {error, Cause}
     end.
@@ -908,8 +922,12 @@ send_chunk(_Req,_Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport) 
         {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand children
             %% ?access_log_get(Bucket, Key, ChunkSize, ?HTTP_ST_OK),
-            Transport:send(Socket, Bin),
-            CurPos + ChunkSize;
+            case Transport:send(Socket, Bin) of
+                ok ->
+                    CurPos + ChunkSize;
+                {error, Cause} ->
+                    {error, Cause}
+            end;
         Error ->
             Error
     end;
@@ -929,8 +947,12 @@ send_chunk(_Req, _Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport)
         {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand childs
             %% ?access_log_get(Bucket, Key, ChunkSize, ?HTTP_ST_OK),
-            Transport:send(Socket, Bin),
-            CurPos + ChunkSize;
+            case Transport:send(Socket, Bin) of
+                ok ->
+                    CurPos + ChunkSize;
+                {error, Cause} ->
+                    {error, Cause}
+            end;
         {error, Cause} ->
             {error, Cause}
     end.

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -765,10 +765,16 @@ get_body_length([], _ObjectSize, Acc) ->
     Acc;
 get_body_length([{Start, infinity}|Rest], ObjectSize, Acc) ->
     get_body_length(Rest, ObjectSize, Acc + ObjectSize - Start);
+get_body_length([{Start, End}|Rest], ObjectSize, Acc) when End < 0 ->
+    get_body_length(Rest, ObjectSize, Acc + ObjectSize - Start);
 get_body_length([{Start, End}|Rest], ObjectSize, Acc) when End < ObjectSize ->
     get_body_length(Rest, ObjectSize, Acc + End - Start + 1);
-get_body_length([End|Rest], ObjectSize, Acc) when End < ObjectSize->
-    get_body_length(Rest, ObjectSize, Acc + End + 1).
+get_body_length([End|Rest], ObjectSize, Acc) when End < 0 ->
+    get_body_length(Rest, ObjectSize, Acc + ObjectSize);
+get_body_length([End|Rest], ObjectSize, Acc) when End < ObjectSize ->
+    get_body_length(Rest, ObjectSize, Acc + End + 1);
+get_body_length(_, _, _) ->
+    error.
 
 get_range_object_1(Req,_Bucket,_Key, [], _, _Socket, _Transport) ->
     {ok, Req};

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -740,28 +740,34 @@ get_range_object(Req, Bucket, Key, {_Unit, Range}) when is_list(Range) ->
     Mime = leo_mime:guess_mime(Key),
     Header = [?SERVER_HEADER,
               {?HTTP_HEAD_RESP_CONTENT_TYPE,  Mime}],
-    {ok, Req2} = cowboy_req:chunked_reply(?HTTP_ST_PARTIAL_CONTENT, Header, Req),
-    get_range_object_1(Req2, Bucket, Key, Range, undefined).
+    Req2 = cowboy_req:set_resp_body_fun(
+             fun(Socket, Transport) ->
+                     get_range_object_1(Req, Bucket, Key, Range, undefined, Socket, Transport)
+             end, Req),
+    ?reply_ok(Header, Req2).
+%    {ok, Req2} = cowboy_req:chunked_reply(?HTTP_ST_PARTIAL_CONTENT, Header, Req),
+%    get_range_object_1(Req2, Bucket, Key, Range, undefined).
 
-get_range_object_1(Req,_Bucket,_Key, [], _) ->
-    {ok, Req};
-get_range_object_1(Req,_Bucket,_Key, _, {error, _}) ->
-    {ok, Req};
-get_range_object_1(Req, Bucket, Key, [{Start, infinity}|Rest], _) ->
-    Ret = get_range_object_2(Req, Bucket, Key, Start, 0),
-    get_range_object_1(Req, Bucket, Key, Rest, Ret);
-get_range_object_1(Req, Bucket, Key, [{Start, End}|Rest], _) ->
-    Ret = get_range_object_2(Req, Bucket, Key, Start, End),
-    get_range_object_1(Req, Bucket, Key, Rest, Ret);
-get_range_object_1(Req, Bucket, Key, [End|Rest], _) ->
-    Ret = get_range_object_2(Req, Bucket, Key, 0, End),
-    get_range_object_1(Req, Bucket, Key, Rest, Ret).
 
-get_range_object_2(Req, Bucket, Key, Start, End) ->
+get_range_object_1(Req,_Bucket,_Key, [], _, _Socket, _Transport) ->
+    {ok, Req};
+get_range_object_1(Req,_Bucket,_Key, _, {error, _}, _Socket, _Transport) ->
+    {ok, Req};
+get_range_object_1(Req, Bucket, Key, [{Start, infinity}|Rest], _, Socket, Transport) ->
+    Ret = get_range_object_2(Req, Bucket, Key, Start, 0, Socket, Transport),
+    get_range_object_1(Req, Bucket, Key, Rest, Ret, Socket, Transport);
+get_range_object_1(Req, Bucket, Key, [{Start, End}|Rest], _, Socket, Transport) ->
+    Ret = get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport),
+    get_range_object_1(Req, Bucket, Key, Rest, Ret, Socket, Transport);
+get_range_object_1(Req, Bucket, Key, [End|Rest], _, Socket, Transport) ->
+    Ret = get_range_object_2(Req, Bucket, Key, 0, End, Socket, Transport),
+    get_range_object_1(Req, Bucket, Key, Rest, Ret, Socket, Transport).
+
+get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport) ->
     case leo_gateway_rpc_handler:head(Key) of
         {ok, #?METADATA{del = 0,
                         cnumber = 0}} ->
-            get_range_object_small(Req, Bucket, Key, Start, End);
+            get_range_object_small(Req, Bucket, Key, Start, End, Socket, Transport);
         {ok, #?METADATA{del = 0,
                         cnumber = N,
                         dsize = ObjectSize,
@@ -784,7 +790,8 @@ get_range_object_2(Req, Bucket, Key, Start, End) ->
                         {CurPos, Index}
                 end,
             get_range_object_large(Req, Bucket, Key,
-                                   NewStartPos, NewEndPos, N, Index_1, CurPos_1);
+                                   NewStartPos, NewEndPos, N, Index_1, CurPos_1,
+                                   Socket, Transport);
         {error, unavailable} ->
             ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
         _ ->
@@ -794,14 +801,15 @@ get_range_object_2(Req, Bucket, Key, Start, End) ->
 
 %% @doc Retrieve the small object
 %% @private
-get_range_object_small(Req, Bucket, Key, Start, End) ->
+get_range_object_small(Req, Bucket, Key, Start, End, Socket, Transport) ->
     case leo_gateway_rpc_handler:get(Key, Start, End) of
         {ok, _Meta, <<>>} ->
             ?access_log_get(Bucket, Key, 0, ?HTTP_ST_OK),
             ok;
         {ok, _Meta, Bin} ->
             ?access_log_get(Bucket, Key, byte_size(Bin), ?HTTP_ST_OK),
-            cowboy_req:chunk(Bin, Req);
+            %cowboy_req:chunk(Bin, Req);
+            Transport:send(Socket, Bin);
         {error, unavailable} ->
             ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req);
         {error, Cause} ->
@@ -830,11 +838,11 @@ calc_pos(StartPos, EndPos, _ObjectSize) ->
 
 %% @doc Retrieve the large object
 %% @private
-get_range_object_large(_Req,_Bucket,_Key,_Start,_End, Total, Total, CurPos) ->
+get_range_object_large(_Req,_Bucket,_Key,_Start,_End, Total, Total, CurPos, _Socket, _Transport) ->
     {ok, CurPos};
-get_range_object_large(_Req,_Bucket,_Key,_Start, End,_Total,_Index, CurPos) when CurPos > End ->
+get_range_object_large(_Req,_Bucket,_Key,_Start, End,_Total,_Index, CurPos, _Socket, _Transport) when CurPos > End ->
     {ok, CurPos};
-get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos) ->
+get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos, Socket, Transport) ->
     IndexBin = list_to_binary(integer_to_list(Index + 1)),
     Key2 = << Key/binary, ?DEF_SEPARATOR/binary, IndexBin/binary >>,
 
@@ -842,13 +850,13 @@ get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos) ->
         {ok, #?METADATA{cnumber = 0,
                         dsize = CS}} ->
             %% get and chunk an object
-            NewPos = send_chunk(Req, Bucket, Key2, Start, End, CurPos, CS),
-            get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos);
+            NewPos = send_chunk(Req, Bucket, Key2, Start, End, CurPos, CS, Socket, Transport),
+            get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos, Socket, Transport);
 
         {ok, #?METADATA{cnumber = GrandChildNum}} ->
-            case get_range_object_large(Req, Bucket, Key2, Start, End, GrandChildNum, 0, CurPos) of
+            case get_range_object_large(Req, Bucket, Key2, Start, End, GrandChildNum, 0, CurPos, Socket, Transport) of
                 {ok, NewPos} ->
-                    get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos);
+                    get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos, Socket, Transport);
                 {error, Cause} ->
                     {error, Cause}
             end;
@@ -860,22 +868,23 @@ get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos) ->
 
 %% @doc
 %% @private
-send_chunk(_Req,_,_Key, Start,_End, CurPos, ChunkSize) when (CurPos + ChunkSize - 1) < Start ->
+send_chunk(_Req,_,_Key, Start,_End, CurPos, ChunkSize, _Socket, _Transport) when (CurPos + ChunkSize - 1) < Start ->
     %% skip proc
     CurPos + ChunkSize;
-send_chunk(Req,_Bucket, Key, Start, End, CurPos, ChunkSize) when CurPos >= Start andalso
+send_chunk(_Req,_Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport) when CurPos >= Start andalso
                                                                  (CurPos + ChunkSize - 1) =< End ->
     %% whole get
     case leo_gateway_rpc_handler:get(Key) of
         {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand children
             %% ?access_log_get(Bucket, Key, ChunkSize, ?HTTP_ST_OK),
-            cowboy_req:chunk(Bin, Req),
+            %cowboy_req:chunk(Bin, Req),
+            Transport:send(Socket, Bin),
             CurPos + ChunkSize;
         Error ->
             Error
     end;
-send_chunk(Req, _Bucket, Key, Start, End, CurPos, ChunkSize) ->
+send_chunk(_Req, _Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport) ->
     %% partial get
     StartPos = case Start =< CurPos of
                    true -> 0;
@@ -891,7 +900,8 @@ send_chunk(Req, _Bucket, Key, Start, End, CurPos, ChunkSize) ->
         {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand childs
             %% ?access_log_get(Bucket, Key, ChunkSize, ?HTTP_ST_OK),
-            cowboy_req:chunk(Bin, Req),
+            %cowboy_req:chunk(Bin, Req),
+            Transport:send(Socket, Bin),
             CurPos + ChunkSize;
         {error, Cause} ->
             {error, Cause}

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -744,6 +744,7 @@ get_range_object(Req, Bucket, Key, {_Unit, Range}) when is_list(Range) ->
                       {?HTTP_HEAD_RESP_CONTENT_TYPE,  Mime},
                       {?HTTP_HEAD_RESP_CONTENT_LENGTH,integer_to_list(Length)}],
             Req2 = cowboy_req:set_resp_body_fun(
+                     Length,
                      fun(Socket, Transport) ->
                              get_range_object_1(Req, Bucket, Key, Range, undefined, Socket, Transport)
                      end, 

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -741,8 +741,8 @@ get_range_object(Req, Bucket, Key, {_Unit, Range}) when is_list(Range) ->
     case get_body_length_1(Key, Range) of
         {ok, Length} ->
             Header = [?SERVER_HEADER,
-                      {?HTTP_HEAD_RESP_CONTENT_TYPE,  Mime},
-                      {?HTTP_HEAD_RESP_CONTENT_LENGTH,integer_to_list(Length)}],
+                      {?HTTP_HEAD_RESP_CONTENT_TYPE,  Mime}
+                     ],
             Req2 = cowboy_req:set_resp_body_fun(
                      Length,
                      fun(Socket, Transport) ->

--- a/test/leo_gateway_web_tests.erl
+++ b/test/leo_gateway_web_tests.erl
@@ -660,7 +660,7 @@ range_object_base([_TermFun, _Node0, Node1], RangeValue) ->
                                                  ?TARGET_HOST,
                                                  ":8080/a/b.png"]),
                                    [{"connection", "close"},{"range", RangeValue}]}, [], []),
-                ?assertEqual(206, SC),
+                ?assertEqual(200, SC),
                 ?assertEqual("od", Body)
             catch
                 throw:Reason ->

--- a/test/leo_gateway_web_tests.erl
+++ b/test/leo_gateway_web_tests.erl
@@ -660,7 +660,7 @@ range_object_base([_TermFun, _Node0, Node1], RangeValue) ->
                                                  ?TARGET_HOST,
                                                  ":8080/a/b.png"]),
                                    [{"connection", "close"},{"range", RangeValue}]}, [], []),
-                ?assertEqual(200, SC),
+                ?assertEqual(206, SC),
                 ?assertEqual("od", Body)
             catch
                 throw:Reason ->


### PR DESCRIPTION
About issue leo-project/leofs#376

Instead of using transfer-encoding:chunked, respond with HTTP 200 and resp_body_func
(Note: aws-java-jdk is case-sensitive to HTTP Headers... cowboy internally uses lower case which does not match)

Code is not polished at the moment, I have only tested with a short Java program

Also Unit test is broken at the moment because it checks against transfer-encoding:chunked