### PR TITLE
Support AWS Signature Version 4

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -70,6 +70,8 @@
 -define(HTTP_HEAD_X_AMZ_ID_2,                   <<"x-amz-id-2">>).
 -define(HTTP_HEAD_X_AMZ_REQ_ID,                 <<"x-amz-request-id">>).
 -define(HTTP_HEAD_X_AMZ_ACL,                    <<"x-amz-acl">>).
+-define(HTTP_HEAD_X_AMZ_CONTENT_SHA256,         <<"x-amz-content-sha256">>).
+-define(HTTP_HRAD_X_AMZ_DATE,                   <<"x-amz-date">>).
 -define(HTTP_HEAD_X_AMZ_META_DIRECTIVE_COPY,    <<"COPY">>).
 -define(HTTP_HEAD_X_AMZ_META_DIRECTIVE_REPLACE, <<"REPLACE">>).
 -define(HTTP_HEAD_X_FROM_CACHE,                 <<"x-from-cache">>).

--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -55,6 +55,7 @@
 -define(HTTP_HEAD_LAST_MODIFIED,      <<"last-modified">>).
 -define(HTTP_HEAD_PREFIX,             <<"prefix">>).
 -define(HTTP_HEAD_RANGE,              <<"range">>).
+-define(HTTP_HEAD_CONTENT_ENCODING,   <<"content-encoding">>).
 
 -define(HTTP_HEAD_RESP_AGE,               <<"Age">>).
 -define(HTTP_HEAD_RESP_CACHE_CTRL,        <<"Cache-Control">>).
@@ -395,6 +396,7 @@
           is_multi_delete = false    :: boolean(),              %% is multi delete request?
           %% for large-object
           is_upload = false            :: boolean(),            %% is upload operation? (for multipart upload)
+          is_aws_chunked = false       :: boolean(),            %% is AWS Chunked? (Signature V4)
           is_acl = false               :: boolean(),            %% is acl operation?
           upload_id = <<>>             :: binary(),             %% upload id for multipart upload
           upload_part_num = 0          :: non_neg_integer(),    %% upload part number for multipart upload
@@ -403,7 +405,8 @@
           max_len_of_obj = 0           :: non_neg_integer(),    %% max length a object (byte)
           chunked_obj_len = 0          :: non_neg_integer(),    %% chunked object length for large-object (byte)
           reading_chunked_obj_len = 0  :: non_neg_integer(),    %% creading hunked object length for large object (byte)
-          threshold_of_chunk_len = 0   :: non_neg_integer()     %% threshold of chunk length for large-object (byte)
+          threshold_of_chunk_len = 0   :: non_neg_integer(),    %% threshold of chunk length for large-object (byte)
+          content_decode_fun = fun(Bin)->{ok,Bin}end :: function()  %% content decode function
          }).
 
 -record(cache, {

--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,7 @@
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {branch, "1.4"}}},
         {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.15"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.6"}}},
-        {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {tag, "1.1.8"}}},
+        {leo_s3_libs,           ".*", {git, "https://github.com/windkit/leo_s3_libs.git",               {branch, "sign_v4"}}},
         {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "0.8.2"}}},
         {savanna_agent,         ".*", {git, "https://github.com/leo-project/savanna_agent.git",         {tag, "0.4.9"}}},
         {erpcgen,               ".*", {git, "https://github.com/leo-project/erpcgen.git",               {tag, "0.2.3"}}},

--- a/test/leo_gateway_web_tests.erl
+++ b/test/leo_gateway_web_tests.erl
@@ -367,7 +367,7 @@ get_bucket_acl_normal1_([_TermFun, _Node0,_Node1]) ->
             try
                 {ok, {SC,Body}} =
                     httpc:request(get, {lists:append(["http://",
-                                                      ?TARGET_HOST, ":8080/bucket?acl"]), [{"Authorization","auth:hoge"}]},
+                                                      ?TARGET_HOST, ":8080/bucket?acl"]), [{"Authorization","AWS auth:hoge"}]},
                                   [], [{full_result, false}]),
                 ?assertEqual(200, SC),
                 {_XmlDoc, Rest} = xmerl_scan:string(Body),


### PR DESCRIPTION
### Brief Description
 - Related to issue leo-project/leofs#283 leo-project/leofs#373

The flow is similar to Version 2 with two major differences
 - Payload SHA-256 is used for Signature
 - Chunked Upload

### Related Pull Requests
 - https://github.com/leo-project/leo_gateway/pull/23
 - https://github.com/leo-project/leo_s3_libs/pull/1

### Using Authorization Header
#### Checksum Precomputed
http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
 - SHA-256 Checksum Provided in HTTP Header `x-amz-content-sha256`
 - Small Modification

#### Amazon Chunked Upload
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
 - "Rolling" Checksum of Chunks

### Using Query Parameters
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

### Using HTTP Post
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html