### PR TITLE
Support AWS Signature Version 4 (Refactored)

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -55,6 +55,7 @@
 -define(HTTP_HEAD_LAST_MODIFIED,      <<"last-modified">>).
 -define(HTTP_HEAD_PREFIX,             <<"prefix">>).
 -define(HTTP_HEAD_RANGE,              <<"range">>).
+-define(HTTP_HEAD_CONTENT_ENCODING,   <<"content-encoding">>).
 
 -define(HTTP_HEAD_RESP_AGE,               <<"Age">>).
 -define(HTTP_HEAD_RESP_CACHE_CTRL,        <<"Cache-Control">>).
@@ -70,6 +71,8 @@
 -define(HTTP_HEAD_X_AMZ_ID_2,                   <<"x-amz-id-2">>).
 -define(HTTP_HEAD_X_AMZ_REQ_ID,                 <<"x-amz-request-id">>).
 -define(HTTP_HEAD_X_AMZ_ACL,                    <<"x-amz-acl">>).
+-define(HTTP_HEAD_X_AMZ_CONTENT_SHA256,         <<"x-amz-content-sha256">>).
+-define(HTTP_HRAD_X_AMZ_DATE,                   <<"x-amz-date">>).
 -define(HTTP_HEAD_X_AMZ_META_DIRECTIVE_COPY,    <<"COPY">>).
 -define(HTTP_HEAD_X_AMZ_META_DIRECTIVE_REPLACE, <<"REPLACE">>).
 -define(HTTP_HEAD_X_FROM_CACHE,                 <<"x-from-cache">>).
@@ -393,6 +396,7 @@
           is_multi_delete = false    :: boolean(),              %% is multi delete request?
           %% for large-object
           is_upload = false            :: boolean(),            %% is upload operation? (for multipart upload)
+          is_aws_chunked = false       :: boolean(),            %% is AWS Chunked? (Signature V4)
           is_acl = false               :: boolean(),            %% is acl operation?
           upload_id = <<>>             :: binary(),             %% upload id for multipart upload
           upload_part_num = 0          :: non_neg_integer(),    %% upload part number for multipart upload
@@ -401,7 +405,8 @@
           max_len_of_obj = 0           :: non_neg_integer(),    %% max length a object (byte)
           chunked_obj_len = 0          :: non_neg_integer(),    %% chunked object length for large-object (byte)
           reading_chunked_obj_len = 0  :: non_neg_integer(),    %% creading hunked object length for large object (byte)
-          threshold_of_chunk_len = 0   :: non_neg_integer()     %% threshold of chunk length for large-object (byte)
+          threshold_of_chunk_len = 0   :: non_neg_integer(),    %% threshold of chunk length for large-object (byte)
+          content_decode_fun = fun(Bin)->{ok,Bin}end :: function()  %% content decode function
          }).
 
 -record(cache, {

--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -72,6 +72,7 @@
 -define(HTTP_HEAD_X_AMZ_REQ_ID,                 <<"x-amz-request-id">>).
 -define(HTTP_HEAD_X_AMZ_ACL,                    <<"x-amz-acl">>).
 -define(HTTP_HEAD_X_AMZ_CONTENT_SHA256,         <<"x-amz-content-sha256">>).
+-define(HTTP_HEAD_X_AMZ_DECODED_CONTENT_LENGTH, <<"x-amz-decoded-content-length">>).
 -define(HTTP_HRAD_X_AMZ_DATE,                   <<"x-amz-date">>).
 -define(HTTP_HEAD_X_AMZ_META_DIRECTIVE_COPY,    <<"COPY">>).
 -define(HTTP_HEAD_X_AMZ_META_DIRECTIVE_REPLACE, <<"REPLACE">>).
@@ -344,6 +345,23 @@
                       "</Key><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"])).
 
 %% Records
+-type aws_chunk_state() ::  wait_size | wait_head | read_chunk | error | done.
+
+-record(aws_chunk_sign_params, {sign_head       :: binary(),
+                                sign_key        :: binary(),
+                                prev_sign       :: binary(),
+                                chunk_sign      :: binary(),
+                                chunk_size      :: non_neg_integer(),
+                                hash_context    :: undefined | {crypto:digest_type(), binary()}
+                               }).
+
+-record(aws_chunk_decode_state, {buffer         :: binary(),
+                                 dec_state      :: aws_chunk_state(),
+                                 chunk_offset   :: non_neg_integer(),
+                                 sign_params    :: #aws_chunk_sign_params{},
+                                 total_len      :: non_neg_integer()
+                                }).
+
 -record(http_options, {
           %% for basic
           handler                      :: atom(),         %% http-handler
@@ -406,7 +424,8 @@
           chunked_obj_len = 0          :: non_neg_integer(),    %% chunked object length for large-object (byte)
           reading_chunked_obj_len = 0  :: non_neg_integer(),    %% creading hunked object length for large object (byte)
           threshold_of_chunk_len = 0   :: non_neg_integer(),    %% threshold of chunk length for large-object (byte)
-          content_decode_fun = fun(Bin)->{ok,Bin}end :: function()  %% content decode function
+          transfer_decode_fun       :: function() | undefined,  %% transfer decode function
+          transfer_decode_state     :: #aws_chunk_decode_state{} | undefined    %% transfer decode state
          }).
 
 -record(cache, {

--- a/rebar.config
+++ b/rebar.config
@@ -24,13 +24,12 @@
 
 {deps, [
         {leo_cache,             ".*", {git, "https://github.com/leo-project/leo_cache.git",             {tag, "0.6.5"}}},
-%        {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.1.2"}}},
-        {leo_commons,           ".*", {git, "https://github.com/windkit/leo_commons.git",           {branch, "sign_v4"}}},
+        {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {branch, "develop"}}},
         {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.1.6"}}},
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {branch, "1.4"}}},
         {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.15"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.6"}}},
-        {leo_s3_libs,           ".*", {git, "https://github.com/windkit/leo_s3_libs.git",               {branch, "sign_v4"}}},
+        {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {branch, "1.4"}}},
         {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "0.8.2"}}},
         {savanna_agent,         ".*", {git, "https://github.com/leo-project/savanna_agent.git",         {tag, "0.4.9"}}},
         {erpcgen,               ".*", {git, "https://github.com/leo-project/erpcgen.git",               {tag, "0.2.3"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,8 @@
 
 {deps, [
         {leo_cache,             ".*", {git, "https://github.com/leo-project/leo_cache.git",             {tag, "0.6.5"}}},
-        {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.1.2"}}},
+%        {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.1.2"}}},
+        {leo_commons,           ".*", {git, "https://github.com/windkit/leo_commons.git",           {branch, "sign_v4"}}},
         {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.1.6"}}},
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {branch, "1.4"}}},
         {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.15"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,7 @@
         {leo_object_storage,    ".*", {git, "https://github.com/leo-project/leo_object_storage.git",    {branch, "1.4"}}},
         {leo_redundant_manager, ".*", {git, "https://github.com/leo-project/leo_redundant_manager.git", {tag, "1.9.15"}}},
         {leo_statistics,        ".*", {git, "https://github.com/leo-project/leo_statistics.git",        {tag, "1.1.6"}}},
-        {leo_s3_libs,           ".*", {git, "https://github.com/leo-project/leo_s3_libs.git",           {tag, "1.1.8"}}},
+        {leo_s3_libs,           ".*", {git, "https://github.com/windkit/leo_s3_libs.git",               {branch, "sign_v4"}}},
         {leo_watchdog,          ".*", {git, "https://github.com/leo-project/leo_watchdog.git",          {tag, "0.8.2"}}},
         {savanna_agent,         ".*", {git, "https://github.com/leo-project/savanna_agent.git",         {tag, "0.4.9"}}},
         {erpcgen,               ".*", {git, "https://github.com/leo-project/erpcgen.git",               {tag, "0.2.3"}}},

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -48,7 +48,8 @@
           timeout_for_body     :: pos_integer(),
           chunked_size         :: pos_integer(),
           reading_chunked_size :: pos_integer(),
-          content_decode_fun   :: function()
+          transfer_decode_fun  :: function(),
+          transfer_decode_state:: #aws_chunk_decode_state{}
          }).
 
 
@@ -475,7 +476,8 @@ put_object(Req, Key, #req_params{bucket = Bucket,
                                  timeout_for_body = Timeout4Body,
                                  max_len_of_obj = MaxLenForObj,
                                  threshold_of_chunk_len = ThresholdObjLen,
-                                 content_decode_fun = ContentDecodeFun
+                                 transfer_decode_fun = TransferDecodeFun,
+                                 transfer_decode_state = TransferDecodeState
                                 } = Params) ->
     {Size, _} = cowboy_req:body_length(Req),
     ?debug("put_object/3", "Object Size: ~p", [Size]),
@@ -493,8 +495,13 @@ put_object(Req, Key, #req_params{bucket = Bucket,
         false ->
             Ret = case cowboy_req:has_body(Req) of
                       true ->
-                          BodyOpts = [{read_timeout, Timeout4Body},
-                                      {content_decode, ContentDecodeFun}],
+                          BodyOpts = case TransferDecodeFun of
+                                        undefined ->
+                                            [{read_timeout, Timeout4Body}];
+                                        _ ->
+                                            [{read_timeout, Timeout4Body},
+                                             {transfer_decode, TransferDecodeFun, TransferDecodeState}]
+                                     end,
                           case cowboy_req:body(Req, BodyOpts) of
                               {ok, Bin0, Req0} ->
                                   {ok, {Size, Bin0, Req0}};
@@ -569,7 +576,8 @@ put_large_object(Req, Key, Size, #req_params{bucket = Bucket,
                                              timeout_for_body = Timeout4Body,
                                              chunked_obj_len = ChunkedSize,
                                              reading_chunked_obj_len = ReadingChunkedSize,
-                                             content_decode_fun = ContentDecodeFun
+                                             transfer_decode_fun = TransferDecodeFun,
+                                             transfer_decode_state = TransferDecodeState
                                             })->
     %% launch 'large_object_handler'
     {ok, Handler}  = leo_large_object_put_handler:start_link(Key, ChunkedSize),
@@ -582,17 +590,25 @@ put_large_object(Req, Key, Size, #req_params{bucket = Bucket,
     %% then put it to the storage-cluster
     BodyOpts = [{length, ReadingChunkedSize},
                 {read_timeout, Timeout4Body},
-                {read_length, ReadingChunkedSize},
-                {content_decode, ContentDecodeFun}
+                {read_length, ReadingChunkedSize}
                ],
-    Reply = case put_large_object_1(cowboy_req:body(Req, BodyOpts),
+    BodyOpts_1 = case TransferDecodeFun of
+                    undefined ->
+                        BodyOpts;
+                    _ ->
+                        [{transfer_decode, TransferDecodeFun, TransferDecodeState} | BodyOpts]
+                 end,
+    Reply = case put_large_object_1(cowboy_req:body(Req, BodyOpts_1),
                                     #req_large_obj{handler = Handler,
                                                    key     = Key,
                                                    length  = Size,
                                                    timeout_for_body = Timeout4Body,
                                                    chunked_size = ChunkedSize,
                                                    reading_chunked_size = ReadingChunkedSize,
-                                                   content_decode_fun = ContentDecodeFun}) of
+                                                   transfer_decode_fun = TransferDecodeFun,
+                                                   transfer_decode_state = TransferDecodeState
+
+                                                  }) of
                 {error, ErrorRet} ->
                     ok = leo_large_object_put_handler:rollback(Handler),
                     {Req_1, Cause} = case (erlang:size(ErrorRet) == 2) of
@@ -621,16 +637,22 @@ put_large_object_1({more, Data, Req},
                                   handler = Handler,
                                   timeout_for_body = Timeout4Body,
                                   reading_chunked_size = ReadingChunkedSize,
-                                  content_decode_fun = ContentDecodeFun
+                                  transfer_decode_fun = TransferDecodeFun,
+                                  transfer_decode_state = TransferDecodeState
                                  } = ReqLargeObj) ->
     case catch leo_large_object_put_handler:put(Handler, Data) of
         ok ->
             BodyOpts = [{length, ReadingChunkedSize},
                         {read_timeout, Timeout4Body},
-                        {read_length, ReadingChunkedSize},
-                        {content_decode, ContentDecodeFun}
+                        {read_length, ReadingChunkedSize}
                        ],
-            put_large_object_1(cowboy_req:body(Req, BodyOpts), ReqLargeObj);
+            BodyOpts_1 = case TransferDecodeFun of
+                            undefined ->
+                                BodyOpts;
+                            _ ->
+                                [{transfer_decode, TransferDecodeFun, TransferDecodeState} | BodyOpts]
+                         end,
+            put_large_object_1(cowboy_req:body(Req, BodyOpts_1), ReqLargeObj);
         {'EXIT', Cause} ->
             ?error("put_large_object_1/2", "key:~s, cause:~p", [binary_to_list(Key), Cause]),
             {error, {Req, ?ERROR_FAIL_PUT_OBJ}};

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -47,7 +47,8 @@
           length  :: pos_integer(),
           timeout_for_body     :: pos_integer(),
           chunked_size         :: pos_integer(),
-          reading_chunked_size :: pos_integer()
+          reading_chunked_size :: pos_integer(),
+          content_decode_fun   :: function()
          }).
 
 
@@ -473,8 +474,11 @@ put_object(Req, Key, #req_params{bucket = Bucket,
                                  is_upload = IsUpload,
                                  timeout_for_body = Timeout4Body,
                                  max_len_of_obj = MaxLenForObj,
-                                 threshold_of_chunk_len = ThresholdObjLen} = Params) ->
+                                 threshold_of_chunk_len = ThresholdObjLen,
+                                 content_decode_fun = ContentDecodeFun
+                                } = Params) ->
     {Size, _} = cowboy_req:body_length(Req),
+    ?debug("put_object/3", "Object Size: ~p", [Size]),
     case (Size >= ThresholdObjLen) of
         true when Size >= MaxLenForObj ->
             ?access_log_put(Bucket, Key, 0, ?HTTP_ST_BAD_REQ),
@@ -489,7 +493,8 @@ put_object(Req, Key, #req_params{bucket = Bucket,
         false ->
             Ret = case cowboy_req:has_body(Req) of
                       true ->
-                          BodyOpts = [{read_timeout, Timeout4Body}],
+                          BodyOpts = [{read_timeout, Timeout4Body},
+                                      {content_decode, ContentDecodeFun}],
                           case cowboy_req:body(Req, BodyOpts) of
                               {ok, Bin0, Req0} ->
                                   {ok, {Size, Bin0, Req0}};
@@ -563,7 +568,9 @@ put_small_object({ok, {Size, Bin, Req}}, Key, #req_params{bucket = Bucket,
 put_large_object(Req, Key, Size, #req_params{bucket = Bucket,
                                              timeout_for_body = Timeout4Body,
                                              chunked_obj_len = ChunkedSize,
-                                             reading_chunked_obj_len = ReadingChunkedSize})->
+                                             reading_chunked_obj_len = ReadingChunkedSize,
+                                             content_decode_fun = ContentDecodeFun
+                                            })->
     %% launch 'large_object_handler'
     {ok, Handler}  = leo_large_object_put_handler:start_link(Key, ChunkedSize),
 
@@ -575,14 +582,17 @@ put_large_object(Req, Key, Size, #req_params{bucket = Bucket,
     %% then put it to the storage-cluster
     BodyOpts = [{length, ReadingChunkedSize},
                 {read_timeout, Timeout4Body},
-                {read_length, ReadingChunkedSize}],
+                {read_length, ReadingChunkedSize},
+                {content_decode, ContentDecodeFun}
+               ],
     Reply = case put_large_object_1(cowboy_req:body(Req, BodyOpts),
                                     #req_large_obj{handler = Handler,
                                                    key     = Key,
                                                    length  = Size,
                                                    timeout_for_body = Timeout4Body,
                                                    chunked_size = ChunkedSize,
-                                                   reading_chunked_size = ReadingChunkedSize}) of
+                                                   reading_chunked_size = ReadingChunkedSize,
+                                                   content_decode_fun = ContentDecodeFun}) of
                 {error, ErrorRet} ->
                     ok = leo_large_object_put_handler:rollback(Handler),
                     {Req_1, Cause} = case (erlang:size(ErrorRet) == 2) of
@@ -594,7 +604,8 @@ put_large_object(Req, Key, Size, #req_params{bucket = Bucket,
                             ?reply_timeout([?SERVER_HEADER], Key, <<>>, Req_1);
                         unavailable ->
                             ?reply_service_unavailable_error([?SERVER_HEADER], Key, <<>>, Req_1);
-                        _Other  ->
+                        Other  ->
+                            ?error("put_large_object_1/2", "Other: ~p", [Other]),
                             ?reply_internal_error([?SERVER_HEADER], Key, <<>>, Req_1)
                     end;
                 Ret ->
@@ -609,12 +620,16 @@ put_large_object_1({more, Data, Req},
                    #req_large_obj{key = Key,
                                   handler = Handler,
                                   timeout_for_body = Timeout4Body,
-                                  reading_chunked_size = ReadingChunkedSize} = ReqLargeObj) ->
+                                  reading_chunked_size = ReadingChunkedSize,
+                                  content_decode_fun = ContentDecodeFun
+                                 } = ReqLargeObj) ->
     case catch leo_large_object_put_handler:put(Handler, Data) of
         ok ->
             BodyOpts = [{length, ReadingChunkedSize},
                         {read_timeout, Timeout4Body},
-                        {read_length, ReadingChunkedSize}],
+                        {read_length, ReadingChunkedSize},
+                        {content_decode, ContentDecodeFun}
+                       ],
             put_large_object_1(cowboy_req:body(Req, BodyOpts), ReqLargeObj);
         {'EXIT', Cause} ->
             ?error("put_large_object_1/2", "key:~s, cause:~p", [binary_to_list(Key), Cause]),
@@ -656,7 +671,8 @@ put_large_object_1({ok, Data, Req}, #req_large_obj{handler = Handler,
                         {error,_Cause} ->
                             {error, {Req, ?ERROR_FAIL_PUT_OBJ}}
                     end;
-                {ok, _} ->
+                {ok, #large_obj_info{length = TotalSize}} ->
+                    ?error("put_large_object_1/2", "Length Not Match: ~p ~p", [TotalSize, Size]),
                     {error, {Req, ?ERROR_NOT_MATCH_LENGTH}};
                 {_,_Cause} ->
                     {error, {Req, ?ERROR_FAIL_PUT_OBJ}}
@@ -961,7 +977,6 @@ send_chunk(_Req, _Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport)
         {error, Cause} ->
             {error, Cause}
     end.
-
 
 %%--------------------------------------------------------------------
 %% INNER Functions

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -802,6 +802,10 @@ handle_2({ok, AccessKeyId}, Req, ?HTTP_POST,  Path, Params, State) ->
 handle_2({ok, AccessKeyId}, Req, HTTPMethod, Path, Params, State) ->
     case catch leo_gateway_http_req_handler:handle(
                  HTTPMethod, Req, Path, Params#req_params{access_key_id = AccessKeyId}) of
+        {'EXIT', {"aws-chunked decode failed", _} = Cause} ->
+            ?error("handle_2/6", "path:~s, cause:~p", [binary_to_list(Path), Cause]),
+            {ok, Req_2} = ?reply_forbidden([?SERVER_HEADER], Path, <<>>, Req),
+            {ok, Req_2, State};
         {'EXIT', Cause} ->
             ?error("handle_2/6", "path:~s, cause:~p", [binary_to_list(Path), Cause]),
             {ok, Req_2} = ?reply_internal_error([?SERVER_HEADER], Path, <<>>, Req),

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -636,16 +636,14 @@ aws_chunk_decode({ok, Acc}, IOList, read_chunk, Offset, #aws_chunk_sign_params{
             <<ChunkPart:ChunkRemainSize/binary, "\r\n", Rest/binary>> = Bin,
             Context_2 = crypto:hash_update(Context, ChunkPart),
             ChunkHash = crypto:hash_final(Context_2),
-			ChunkHashHex = leo_hex:binary_to_hex(ChunkHash),
-			ChunkHashBin = list_to_binary(ChunkHashHex),
+            ChunkHashBin = leo_hex:binary_to_hexbin(ChunkHash),
             BinToSign = <<"AWS4-HMAC-SHA256-PAYLOAD\n",
 			              SignHead/binary,
                           PrevSign/binary,  "\n",
                           "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n",
                           ChunkHashBin/binary>>,
             Signature = crypto:hmac(sha256, SignKey, BinToSign),
-            SignatureHex = leo_hex:binary_to_hex(Signature),
-            Sign = list_to_binary(SignatureHex),
+            Sign = leo_hex:binary_to_hexbin(Signature),
             case Sign of
                 ChunkSign ->
                     ?debug("aws_chunk_decode/4", "Output Chunk Size: ~p, Sign: ~p", [ChunkSize, ChunkSign]),

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -678,7 +678,7 @@ aws_chunk_decode({ok, Acc}, Buffer, read_chunk, Offset, #aws_chunk_sign_params{
                             {{error, unmatch}, {Buffer, error, Offset, SignParams}}
                     end
             end;
-        _ ->
+        Len when ChunkRemainSize >= Len ->
             SignParams_2 = case SignHead of
                                undefined ->
                                    SignParams;
@@ -686,7 +686,9 @@ aws_chunk_decode({ok, Acc}, Buffer, read_chunk, Offset, #aws_chunk_sign_params{
                                    Context_2 = crypto:hash_update(Context, Buffer),
                                    SignParams#aws_chunk_sign_params{hash_context = Context_2}
                            end,
-            {{ok, <<Acc/binary, Buffer/binary>>}, {<<>>, read_chunk, Offset + byte_size(Buffer), SignParams_2}}
+            {{ok, <<Acc/binary, Buffer/binary>>}, {<<>>, read_chunk, Offset + Len, SignParams_2}};
+        _ ->
+            {{ok, Acc}, {Buffer, read_chunk, Offset ,SignParams}}
     end.
 
 %% @doc Handle a request (sub)

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -51,12 +51,19 @@
 -include_lib("xmerl/include/xmerl.hrl").
 
 -compile({inline, [handle/2, handle_1/4, handle_2/6,
-                   handle_multi_upload_1/5, handle_multi_upload_2/4, handle_multi_upload_3/3,
+                   handle_multi_upload_1/6, handle_multi_upload_2/4, handle_multi_upload_3/3,
                    gen_upload_key/1, gen_upload_initiate_xml/3, gen_upload_completion_xml/4,
                    resp_copy_obj_xml/2, request_params/2, auth/5, auth/7, auth_1/7,
                    get_bucket_1/6, put_bucket_1/3, delete_bucket_1/2, head_bucket_1/2
                   ]}).
 
+-record(aws_chunk_sign_params, {sign_head  ::binary(),
+                                sign_key   ::binary(),
+                                prev_sign  ::binary(),
+                                chunk_sign ::binary(),
+                                chunk_size ::non_neg_integer(),
+                                hash_context :: binary()
+                               }).
 
 %%--------------------------------------------------------------------
 %% API
@@ -287,8 +294,10 @@ put_object(Req, Key, Params) ->
     put_object(get_x_amz_meta_directive(Req), Req, Key, Params).
 
 %% @doc handle MULTIPLE DELETE request
-put_object(?BIN_EMPTY, Req, _Key, #req_params{is_multi_delete = true} = Params) ->
-    BodyOpts = [{read_timeout, Params#req_params.timeout_for_body}],
+put_object(?BIN_EMPTY, Req, _Key, #req_params{is_multi_delete = true,
+                                              content_decode_fun = ContentDecodeFun} = Params) ->
+    BodyOpts = [{read_timeout, Params#req_params.timeout_for_body},
+                {content_decode, ContentDecodeFun}],
     case cowboy_req:body(Req, BodyOpts) of
         {ok, Body, Req1} ->
             %% Check Content-MD5 with body
@@ -300,7 +309,11 @@ put_object(?BIN_EMPTY, Req, _Key, #req_params{is_multi_delete = true} = Params) 
     end;
 
 put_object(?BIN_EMPTY, Req, Key, Params) ->
-    {Size, _} = cowboy_req:body_length(Req),
+    {Size, _} = case cowboy_req:header(<<"x-amz-decoded-content-length">>, Req) of
+		{undefined, _} -> cowboy_req:body_length(Req);
+		{Val,		_} -> {binary_to_integer(Val), dummy}
+	end,
+	?debug("put_object/4", "Key: ~p, Size: ~p", [Key, Size]),
 
     case (Size >= Params#req_params.threshold_of_chunk_len) of
         true when Size >= Params#req_params.max_len_of_obj ->
@@ -311,7 +324,9 @@ put_object(?BIN_EMPTY, Req, Key, Params) ->
         false ->
             Ret = case cowboy_req:has_body(Req) of
                       true ->
-                          BodyOpts = [{read_timeout, Params#req_params.timeout_for_body}],
+                          ContentDecodeFun = Params#req_params.content_decode_fun,
+                          BodyOpts = [{read_timeout, Params#req_params.timeout_for_body},
+                                      {content_decode, ContentDecodeFun}],
                           case cowboy_req:body(Req, BodyOpts) of
                               {ok, Bin, Req1} ->
                                   {ok, {Size, Bin, Req1}};
@@ -508,8 +523,144 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, CustomHeaderSett
                              timeout_for_body        = Props#http_options.timeout_for_body,
                              reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                              threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len}),
+
+    ?debug("handle_1", "ReqParams: ~p", [ReqParams]),
     AuthRet = auth(Req_2, HTTPMethod, Path_1, TokenLen, ReqParams),
-    handle_2(AuthRet, Req_2, HTTPMethod, Path_1, ReqParams, State).
+    AuthRet_2 = case AuthRet of
+                    {error, Reason} ->
+                        {error, Reason};
+                    {ok, AccessKeyId, {_Signature, _SignHead, _SignKey}} ->
+                        {ok, AccessKeyId}
+                end,
+    ReqParams_2 = case ReqParams#req_params.is_aws_chunked of
+                      true ->
+                          case AuthRet of
+                              {ok, _, {Signature, SignHead, SignKey}} ->
+                                  AWSChunkSignParams = #aws_chunk_sign_params{sign_head = SignHead,
+                                                                              sign_key  = SignKey,
+                                                                              prev_sign = Signature,
+                                                                              chunk_sign= <<>>},
+                                  put(io_list, <<>>),
+                                  put(dec_state, wait_size),
+                                  put(chunk_offset, 0),
+                                  put(sign_params, AWSChunkSignParams),
+                                  AwsChunkedFun = fun(Bin) ->
+                                                          IOList    = get(io_list),
+                                                          DecState  = get(dec_state),
+                                                          Offset = get(chunk_offset),
+                                                          SignParams = get(sign_params),
+%                                                          ?debug("aws_chunk_decode", "IOList Size: ~p, DecState: ~p, ChunkSize: ~p", [iolist_size(IOList), DecState, ChunkSize]),
+%                                                          ?debug("aws_chunk_decode", "SignParams: ~p", [SignParams]),
+                                                          Ret = aws_chunk_decode({ok, <<>>}, [IOList, Bin], DecState, Offset, SignParams),
+                                                          case Ret of
+                                                              {{error, Reason2}, {_, _, _, _}} ->
+%                                                                  ?error("aws_chunk_decode", "Parse Error: ~p", [Reason2]),
+                                                                  {error, Reason2};
+                                                              {{ok, Acc}, {IOList_2, DecState_2, Offset_2, SignParams_2}} ->
+                                                                  put(io_list, IOList_2),
+                                                                  put(dec_state, DecState_2),
+                                                                  put(chunk_offset, Offset_2),
+                                                                  put(sign_params, SignParams_2),
+                                                                  OutBin = iolist_to_binary(Acc),
+%                                                                  ?debug("aws_chunk_decode", "Parse Complete: ~p", [byte_size(OutBin)]),
+                                                                  erlang:garbage_collect(self()),
+                                                                  {ok, OutBin}
+                                                          end
+                                                  end,
+                                  ReqParams#req_params{content_decode_fun = AwsChunkedFun};
+                              _ ->
+                                  ReqParams
+                          end;
+                      _ ->
+                          ReqParams
+                  end,
+
+    handle_2(AuthRet_2, Req_2, HTTPMethod, Path_1, ReqParams_2, State).
+
+extract_atleast(IOList, Size) ->
+    extract_atleast(IOList, Size, []).
+
+extract_atleast([Head, Tail] = IOList, Size, Acc) ->
+    case iolist_size(Acc) of
+        Len when Len >= Size ->
+            {iolist_to_binary(Acc), IOList};
+        _ ->
+            extract_atleast(Tail, Size, [Acc, Head])
+    end;
+extract_atleast(Bin, _Size, Acc) ->
+    {iolist_to_binary([Acc, Bin]), <<>>}.
+
+aws_chunk_decode({error, Reason}, IOList, State, Offset, SignParams) ->
+    {{error,Reason}, {IOList, State, Offset, SignParams}};
+aws_chunk_decode({ok, Acc}, IOList, wait_size, 0, SignParams) ->
+    case erlang:iolist_size(IOList) of
+        Len when Len > 10 ->
+            {Bin, Remains} = extract_atleast(IOList, 10),
+            case binary:match(Bin, <<";">>) of
+                nomatch ->
+                    {{error, incorrect}, {IOList, error, 0, SignParams}};
+                {Start, _} ->
+                    <<SizeHexBin:Start/binary, ";", Rest/binary>> = Bin,
+                    SizeHex = binary_to_list(SizeHexBin),
+                    Size = leo_hex:hex_to_integer(SizeHex),
+%                    ?debug("aws_chunk_decode", "Chunk Size: ~p", [Size]),
+                    Context = crypto:hash_init(sha256),
+                    aws_chunk_decode({ok, Acc}, [Rest, Remains], wait_head, 0, SignParams#aws_chunk_sign_params{chunk_size = Size,
+                                                                                                                hash_context = Context})
+            end;
+        _ ->
+            {{ok, Acc}, {IOList, wait_size, 0, SignParams}}
+    end;
+aws_chunk_decode({ok, Acc}, IOList, wait_head, 0, SignParams) ->
+    case erlang:iolist_size(IOList) of
+        Len when Len > 80 + 2 ->
+            {Bin, Remains} = extract_atleast(IOList, 80 + 2),
+            <<"chunk-signature=", ChunkSign:64/binary, "\r\n", Rest/binary>> = Bin,
+%            ?debug("aws_chunk_decode", "Chunk Sign: ~p", [ChunkSign]),
+            aws_chunk_decode({ok, Acc}, [Rest, Remains], read_chunk, 0, SignParams#aws_chunk_sign_params{chunk_sign = ChunkSign});
+        _ ->
+            {{ok, Acc}, {IOList, wait_head, 0, SignParams}}
+    end;
+aws_chunk_decode({ok, Acc}, IOList, read_chunk, Offset, #aws_chunk_sign_params{
+                                                  sign_head  = SignHead, 
+                                                  sign_key   = SignKey, 
+                                                  prev_sign  = PrevSign,
+                                                  chunk_sign = ChunkSign,
+                                                  chunk_size = ChunkSize,
+                                                  hash_context = Context
+                                                 } = SignParams) ->
+    ChunkRemainSize = ChunkSize - Offset,
+    case erlang:iolist_size(IOList) of
+        Len when Len >= ChunkRemainSize + 2 ->
+            {Bin, Remains} = extract_atleast(IOList, ChunkRemainSize + 2),
+            <<ChunkPart:ChunkRemainSize/binary, "\r\n", Rest/binary>> = Bin,
+            Context_2 = crypto:hash_update(Context, ChunkPart),
+            ChunkHash = crypto:hash_final(Context_2),
+			ChunkHashHex = leo_hex:binary_to_hex(ChunkHash),
+			ChunkHashBin = list_to_binary(ChunkHashHex),
+            BinToSign = <<"AWS4-HMAC-SHA256-PAYLOAD\n",
+			              SignHead/binary,
+                          PrevSign/binary,  "\n",
+                          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n",
+                          ChunkHashBin/binary>>,
+            Signature = crypto:hmac(sha256, SignKey, BinToSign),
+            SignatureHex = leo_hex:binary_to_hex(Signature),
+            Sign = list_to_binary(SignatureHex),
+            case Sign of
+                ChunkSign ->
+                    ?debug("aws_chunk_decode/4", "Output Chunk Size: ~p, Sign: ~p", [ChunkSize, ChunkSign]),
+            		aws_chunk_decode({ok, [Acc, ChunkPart]}, [Rest, Remains], wait_size, 0, SignParams#aws_chunk_sign_params{prev_sign = ChunkSign,
+                                                                                                       					 chunk_sign = <<>>});
+                WrongSign ->
+					?debug("aws_chunk_decode/4", "BinToSign: ~p", [binary_to_list(BinToSign)]),
+                    ?error("aws_chunk_decode/4", "Chunk Signature Not Match: ~p, ~p", [WrongSign, ChunkSign]),
+                    {{error, unmatch}, {Bin, error, Offset, SignParams}}
+            end;
+        _ ->
+            Bin = iolist_to_binary(IOList),
+            Context_2 = crypto:hash_update(Context, Bin),
+            {{ok, [Acc, Bin]}, {<<>>, read_chunk, Offset + byte_size(Bin), SignParams#aws_chunk_sign_params{hash_context = Context_2}}}
+    end.
 
 %% @doc Handle a request (sub)
 %% @private
@@ -605,10 +756,11 @@ handle_2({ok,_AccessKeyId}, Req, ?HTTP_POST, _,
                      chunked_obj_len = ChunkedLen,
                      is_upload = false,
                      upload_id = UploadId,
-                     upload_part_num = PartNum}, State) when UploadId /= <<>>,
-                                                             PartNum  == 0 ->
+                     upload_part_num = PartNum,
+                     content_decode_fun = ContentDecodeFun}, State) when UploadId /= <<>>,
+                                                                         PartNum  == 0 ->
     Res = cowboy_req:has_body(Req),
-    {ok, Req_2} = handle_multi_upload_1(Res, Req, Path, UploadId, ChunkedLen),
+    {ok, Req_2} = handle_multi_upload_1(Res, Req, Path, UploadId, ChunkedLen, ContentDecodeFun),
     {ok, Req_2, State};
 
 %% For Regular cases
@@ -631,21 +783,22 @@ handle_2({ok, AccessKeyId}, Req, HTTPMethod, Path, Params, State) ->
 
 %% @doc Handle multi-upload processing
 %% @private
-handle_multi_upload_1(true, Req, Path, UploadId, ChunkedLen) ->
+handle_multi_upload_1(true, Req, Path, UploadId, ChunkedLen, ContentDecodeFun) ->
     Path4Conf = << Path/binary, ?STR_NEWLINE, UploadId/binary >>,
 
     case leo_gateway_rpc_handler:head(Path4Conf) of
         {ok, _} ->
             _ = leo_gateway_rpc_handler:delete(Path4Conf),
 
-            Ret = cowboy_req:body(Req),
+            BodyOpts = [{content_decode, ContentDecodeFun}],
+            Ret = cowboy_req:body(Req, BodyOpts),
             handle_multi_upload_2(Ret, Req, Path, ChunkedLen);
         {error, unavailable} ->
             ?reply_service_unavailable_error([?SERVER_HEADER], Path, <<>>, Req);
         _ ->
             ?reply_forbidden([?SERVER_HEADER], Path, <<>>, Req)
     end;
-handle_multi_upload_1(false, Req, Path,_UploadId,_ChunkedLen) ->
+handle_multi_upload_1(false, Req, Path,_UploadId,_ChunkedLen, _ContentDecodeFun) ->
     ?reply_forbidden([?SERVER_HEADER], Path, <<>>, Req).
 
 handle_multi_upload_2({ok, Bin, Req}, _Req, Path,_ChunkedLen) ->
@@ -788,8 +941,29 @@ request_params(Req, Params) ->
                end,
     Range    = element(1, cowboy_req:header(?HTTP_HEAD_RANGE, Req)),
 
+%%    ?debug("request_params/2", "Headers: ~p", [cowboy_req:headers(Req)]),
+    IsAwsChunked = case cowboy_req:header(<<"x-amz-content-sha256">>, Req) of
+                       {<<"STREAMING-AWS4-HMAC-SHA256-PAYLOAD">>, _} ->
+                           true;
+                       _ ->
+                           false
+                   end,
+%%    IsAwsChunked = case cowboy_req:header(?HTTP_HEAD_CONTENT_ENCODING, Req) of
+%%                       {undefined, _} -> false;
+%%                       {Val,       _} ->
+%%                           ?debug("request_params/2", "Header Content-Encoding: ~p", [Val]),
+%%                           case binary:match(Val, "aws-chunked") of
+%%                               nomatch ->
+%%                                   false;
+%%                               _ ->
+%%                                   true
+%%                           end
+%%                   end,
+    ?debug("request_params/2", "Is AWS Chunked: ~p", [IsAwsChunked]),
+
     Params#req_params{is_multi_delete = IsMultiDelete,
                       is_upload       = IsUpload,
+                      is_aws_chunked  = IsAwsChunked,
                       upload_id       = UploadId,
                       upload_part_num = PartNum,
                       range_header    = Range}.
@@ -873,10 +1047,8 @@ auth_1(Req, HTTPMethod, Path, TokenLen, Bucket, _ACLs, #req_params{is_acl = IsAC
         {undefined, _} ->
             {error, undefined};
         {AuthorizationBin, _} ->
-            case binary:match(AuthorizationBin, <<":">>) of
-                nomatch ->
-                    {error, nomatch};
-                _Found ->
+            case AuthorizationBin of
+                <<Head:4/binary, _Rest/binary>> when Head =:= <<"AWS ">> ; Head =:= <<"AWS4">> ->
                     IsCreateBucketOp = (TokenLen   == 1 andalso
                                         HTTPMethod == ?HTTP_PUT andalso
                                         not IsACL),
@@ -934,6 +1106,13 @@ auth_1(Req, HTTPMethod, Path, TokenLen, Bucket, _ACLs, #req_params{is_acl = IsAC
                                      list_to_binary(Ret)
                              end,
 
+                    SignVer = case Head of
+                                  <<"AWS4">> ->
+                                      v4;
+                                  _ ->
+                                      v2
+                              end,
+
                     SignParams = #sign_params{http_verb     = HTTPMethod,
                                               content_md5   = ?http_header(Req, ?HTTP_HEAD_CONTENT_MD5),
                                               content_type  = ?http_header(Req, ?HTTP_HEAD_CONTENT_TYPE),
@@ -942,8 +1121,12 @@ auth_1(Req, HTTPMethod, Path, TokenLen, Bucket, _ACLs, #req_params{is_acl = IsAC
                                               raw_uri       = RawURI,
                                               requested_uri = Path_1,
                                               query_str     = QStr_3,
+                                              sign_ver      = SignVer,
+                                              req           = Req,
                                               amz_headers   = leo_http:get_amz_headers4cow(Headers)},
-                    leo_s3_auth:authenticate(AuthorizationBin, SignParams, IsCreateBucketOp)
+                    leo_s3_auth:authenticate(AuthorizationBin, SignParams, IsCreateBucketOp);
+                _->
+                    {error, nomatch}
             end
     end.
 

--- a/src/leo_large_object_put_handler.erl
+++ b/src/leo_large_object_put_handler.erl
@@ -145,6 +145,9 @@ handle_call({put, Bin}, _From, #state{key = Key,
                   end,
             SpawnRet = erlang:spawn_monitor(Fun),
             Context_1 = crypto:hash_update(Context, Bin_2),
+			<< Head:8/binary, _Rest/binary>> = Bin_2,
+			Offset = MaxObjLen * NumOfChunks,
+			?debug("handle_call", "Save Chunk, Key: ~p, Chunk: ~p, Offset: ~p, Bin: ~p", [Key, NumOfChunks, Offset, leo_hex:binary_to_hex(Head)]),
             {reply, ok, State#state{stacked_bin   = StackedBin_1,
                                     num_of_chunks = NumOfChunks + 1,
                                     total_len     = TotalLen_1,
@@ -155,8 +158,9 @@ handle_call({put, Bin}, _From, #state{key = Key,
                                     total_len   = TotalLen_1}}
     end;
 
-handle_call({put, _Bin}, _From, #state{key = _Key,
+handle_call({put, _Bin}, _From, #state{key = Key,
                                        errors = Errors} = State) ->
+	?debug("handle_call", "Large Put Failed Key: ~p, Error: ~p", [Key, Errors]),
     {reply, {error, Errors}, State};
 
 handle_call(rollback, _From, #state{key = Key} = State) ->

--- a/test/leo_gateway_web_tests.erl
+++ b/test/leo_gateway_web_tests.erl
@@ -367,7 +367,7 @@ get_bucket_acl_normal1_([_TermFun, _Node0,_Node1]) ->
             try
                 {ok, {SC,Body}} =
                     httpc:request(get, {lists:append(["http://",
-                                                      ?TARGET_HOST, ":8080/bucket?acl"]), [{"Authorization","auth:hoge"}]},
+                                                      ?TARGET_HOST, ":8080/bucket?acl"]), [{"Authorization","AWS auth:hoge"}]},
                                   [], [{full_result, false}]),
                 ?assertEqual(200, SC),
                 {_XmlDoc, Rest} = xmerl_scan:string(Body),

--- a/test/leo_gateway_web_tests.erl
+++ b/test/leo_gateway_web_tests.erl
@@ -73,7 +73,8 @@ gen_tests_1(Arg) ->
                fun delete_object_notfound_/1,
                fun delete_object_normal1_/1,
                fun put_object_error_/1,
-               fun put_object_normal1_/1
+               fun put_object_normal1_/1,
+               fun put_object_aws_chunked_/1
               ]).
 
 gen_tests_2(Arg) ->
@@ -363,7 +364,7 @@ get_bucket_acl_normal1_([_TermFun, _Node0,_Node1]) ->
                                                        permissions = [full_control]}]
                               }}),
             meck:new(leo_s3_auth, [no_link, non_strict]),
-            meck:expect(leo_s3_auth, authenticate, 3, {ok, ["hoge"]}),
+            meck:expect(leo_s3_auth, authenticate, 3, {ok, ["hoge"], undefined}),
             try
                 {ok, {SC,Body}} =
                     httpc:request(get, {lists:append(["http://",
@@ -805,6 +806,70 @@ put_object_normal1_([_TermFun, _Node0, Node1]) ->
                     throw(Reason)
             after
                 ok = rpc:call(Node1, meck, unload, [leo_storage_handler_object])
+            end,
+            ok
+    end.
+
+-define(CHUNKSIZE, 4096).
+-define(AWSCHUNKEDSIZE, 65536).
+
+gen_chunks(PrevSign, SignHead, SignKey, 0, Acc) ->
+    Bin = <<>>,
+    {Chunk, _Signature} = compute_chunk(PrevSign, SignHead, SignKey, Bin),
+    <<Acc/binary, Chunk/binary>>;
+gen_chunks(PrevSign, SignHead, SignKey, Remain, Acc) when Remain < ?CHUNKSIZE ->
+    Bin = crypto:rand_bytes(Remain),
+    {Chunk, Signature} = compute_chunk(PrevSign, SignHead, SignKey, Bin),
+    gen_chunks(Signature, SignHead, SignKey, 0, <<Acc/binary, Chunk/binary>>);
+gen_chunks(PrevSign, SignHead, SignKey, Remain, Acc) ->
+    Bin = crypto:rand_bytes(?CHUNKSIZE),
+    {Chunk, Signature} = compute_chunk(PrevSign, SignHead, SignKey, Bin),
+    gen_chunks(Signature, SignHead, SignKey, Remain - ?CHUNKSIZE, <<Acc/binary, Chunk/binary>>).
+
+compute_chunk(PrevSign, SignHead, SignKey, Bin) ->
+    SizeHex = leo_hex:integer_to_hex(byte_size(Bin), 6),
+    ChunkHashBin = leo_hex:binary_to_hexbin(crypto:hash(sha256, Bin)),
+    BinToSign = <<"AWS4-HMAC-SHA256-PAYLOAD\n",
+                  SignHead/binary,
+                  PrevSign/binary,  "\n",
+                  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\n",
+                  ChunkHashBin/binary>>,
+    Signature = crypto:hmac(sha256, SignKey, BinToSign),
+    Sign = leo_hex:binary_to_hexbin(Signature),
+    SizeHexBin = list_to_binary(SizeHex),
+    Chunk = <<SizeHexBin/binary, ";", "chunk-signature=", Sign/binary, "\r\n", 
+              Bin/binary, "\r\n">>,
+    {Chunk, Sign}.
+
+put_object_aws_chunked_([_TermFun, _Node0, Node1]) ->
+    fun() ->
+            ok = rpc:call(Node1, meck, new,
+                          [leo_storage_handler_object, [no_link, non_strict]]),
+            ok = rpc:call(Node1, meck, expect,
+                          [leo_storage_handler_object, put, 2, {ok, 1}]),
+            meck:new(leo_s3_auth, [no_link, non_strict]),
+            Signature = <<"642797dcfdf817ac23b553420f52c160847d3747b2e86e5ac9d07cc5e7f60f63">>,
+            SignHead = <<"20150706T051217Z\n20150706/us-east-1/s3/aws4_request\n">>,
+            SignKey = <<"2040321d898be34c82d1db9e132124f11eb18a3d21569d1ed58b460b88954ac7">>,
+            meck:expect(leo_s3_auth, authenticate, 3, {ok, <<"05236">>, {Signature, SignHead, SignKey}}),
+            Chunks = gen_chunks(Signature, SignHead, SignKey, ?AWSCHUNKEDSIZE, <<>>),
+            try
+                {ok, {SC, _Body}} =
+                httpc:request(put, {lists:append(["http://",
+                                                  ?TARGET_HOST,
+                                                  ":8080/testjv4/testFile.large.one"]),
+                                    [{"authorization","AWS4-HMAC-SHA256 Credential=05236/20150706/us-east-1/s3/aws4_request, SignedHeaders=content-length, Signature=642797dcfdf817ac23b553420f52c160847d3747b2e86e5ac9d07cc5e7f60f63"},
+                                     {"x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"},
+                                     {"x-amz-decoded-content-length", integer_to_list(?AWSCHUNKEDSIZE)}
+                                    ], "image/png", Chunks},
+                              [], [{full_result, false}]),
+                ?assertEqual(200, SC)
+            catch
+                throw:Reason ->
+                    throw(Reason)
+            after
+                ok = rpc:call(Node1, meck, unload, [leo_storage_handler_object]),
+                ok = meck:unload(leo_s3_auth)
             end,
             ok
     end.


### PR DESCRIPTION
### Brief Description
 - Related to issue leo-project/leofs#283 leo-project/leofs#373

The flow is similar to Version 2 with two major differences
 - Payload SHA-256 is used for Signature
 - Chunked Upload

### Related Pull Requests
 - https://github.com/leo-project/leo_gateway/pull/24
 - https://github.com/leo-project/leo_s3_libs/pull/2
 - https://github.com/leo-project/leo_commons/pull/3

### Work in Progress
 - Unit Test

### Using Authorization Header
#### Checksum Precomputed
http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
 - SHA-256 Checksum Provided in HTTP Header `x-amz-content-sha256`
 - Small Modification

#### Amazon Chunked Upload
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
 - "Rolling" Checksum of Chunks

### Using Query Parameters
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html

### Using HTTP Post
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-authentication-HTTPPOST.html