### PR TITLE
NFS Support for FreeBSD

### DIFF
--- a/src/leo_nfs_file_handler.erl
+++ b/src/leo_nfs_file_handler.erl
@@ -243,7 +243,7 @@ write_small2small(Key, Start, End, Data, SrcMeta, SrcObj) ->
                     case (End + 1) < SrcMeta#?METADATA.dsize of
                         true ->
                             <<Head:Start/binary, _/binary>> = SrcObj,
-                            <<_:End/binary, Tail/binary>> = SrcObj,
+                            <<_:End/binary, _:1/binary, Tail/binary>> = SrcObj,
                             <<Head/binary, Data/binary, Tail/binary>>;
                         false ->
                             <<Head:Start/binary, _/binary>> = SrcObj,


### PR DESCRIPTION
## Fix Issues of NFS with FreeBSD Client

### Identified Issues
 - Cannot use `cp` to read small files
 - Incorrect File Content for Write
 - Cannot list directory

### Underlying Causes
#### Read Small Files
`cp` read files in `chunks` (4KB/8KB/.../64KB) regardless of file size
 - In ubuntu, file size is checked
 - read beyond `chunk` size is regarded as invalid request

#### Incorrect File Content
write requests are not sequential
 - Incorrect Offset Calculation in `read-modify-write` process for small object