### PR TITLE
Implement NFSPROC3_READDIR based on NFSPROC3_READDIRPLUS

### DIFF
--- a/src/leo_nfs_file_handler.erl
+++ b/src/leo_nfs_file_handler.erl
@@ -548,6 +548,15 @@ trim(Key, Size) ->
                                            LargeObjectProp, ?DEF_LOBJ_CHUNK_OBJ_LEN),
     IsLarge = Size > ChunkedObjLen,
     case leo_gateway_rpc_handler:get(Key) of
+        %% TODO Handle Truncate Large Object
+        {error, not_found} when IsLarge =:= false ->
+            Obj = <<0:(8* Size)>>,
+            case leo_gateway_rpc_handler:put(Key, Obj) of
+                {ok, _} ->
+                    ok;
+                Error ->
+                    Error
+            end;
         {ok, #?METADATA{cnumber = 0} = _SrcMeta, SrcObj} when IsLarge =:= false ->
             %% small to small
             %% @todo handle expand case


### PR DESCRIPTION
### Purpose
To support FreeBSD NFS Client
 - Support READDIR operation in NFS, Current Implementation only includes a dummy holder
 - Include File Attributes in the reply of LOOKUP

### Description
READDIR works similarly to READDIRPLUS, except that file attributes are not returned
Essentially, READDIRPLUS = READDIR + GETATTRs

This PR basically copies the implementation from READDIRPLUS with file attributes ripped off.

### Related Issue
https://github.com/leo-project/leo_gateway/issues/27