### PR TITLE
Switched to use leo_net:chunked_send

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -111,7 +111,7 @@
 -define(DEF_HTTP_CUSTOM_HEADER_CONF,  "./http_custom_header.conf").
 -define(DEF_HTTP_TIMEOUT_FOR_HEADER,  5000).
 -define(DEF_HTTP_TIMEOUT_FOR_BODY,    15000).
--define(DEF_HTTP_SEND_CHUNK_LEN,      131072).
+-define(DEF_HTTP_SEND_CHUNK_LEN,      5242880).
 -define(DEF_HTTP_CACHE,               false).
 -define(DEF_HTTP_MAX_KEEPALIVE,       1024).
 -define(DEF_CACHE_WORKERS,            64).
@@ -359,7 +359,7 @@
           headers_config_file = []     :: string(),       %% HTTP custom header configuration file path
           timeout_for_header           :: pos_integer(),  %% Timeout for reading header
           timeout_for_body             :: pos_integer(),  %% Timeout for reading body
-          sending_chunk_len = 0        :: pos_integer(),  %% sending chunk length
+          sending_chunked_obj_len = 0  :: pos_integer(),  %% sending chunk length
           %% for cache
           cache_method                 :: cache_method(), %% cahce method: [http | inner]
           cache_workers = 0            :: pos_integer(),  %% number of chache-fun's workers
@@ -392,7 +392,7 @@
           custom_header_settings     :: list() | undefined,     %% http custom header settings
           timeout_for_header         :: pos_integer(),          %% Timeout for reading header
           timeout_for_body           :: pos_integer(),          %% Timeout for reading body
-          sending_chunk_len = 0      :: pos_integer(),          %% sending chunk length
+          sending_chunked_obj_len    :: pos_integer(),          %% sending chunk length
           qs_prefix = <<>>           :: binary() | none,        %% query string
           range_header               :: string(),               %% range header
           has_inner_cache = false    :: boolean(),              %% has inner-cache?
@@ -426,5 +426,5 @@
           max_content_len = 0  :: integer(),          %% No cache if Content-Length of a response header was &gt this
           content_types   = [] :: list() | undefined, %% like ["image/png", "image/gif", "image/jpeg"]
           path_patterns   = [] :: list() | undefined, %% compiled regular expressions
-          sending_chunk_len = 0:: pos_integer()       %% sending chunk length
+          sending_chunked_obj_len = 0 :: pos_integer()%% sending chunk length
          }).

--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -425,5 +425,6 @@
           expire          = 0  :: integer(),          %% specified per sec
           max_content_len = 0  :: integer(),          %% No cache if Content-Length of a response header was &gt this
           content_types   = [] :: list() | undefined, %% like ["image/png", "image/gif", "image/jpeg"]
-          path_patterns   = [] :: list() | undefined  %% compiled regular expressions
+          path_patterns   = [] :: list() | undefined, %% compiled regular expressions
+          sending_chunk_len = 0:: pos_integer()       %% sending chunk length
          }).

--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -111,6 +111,7 @@
 -define(DEF_HTTP_CUSTOM_HEADER_CONF,  "./http_custom_header.conf").
 -define(DEF_HTTP_TIMEOUT_FOR_HEADER,  5000).
 -define(DEF_HTTP_TIMEOUT_FOR_BODY,    15000).
+-define(DEF_HTTP_SEND_CHUNK_LEN,      131072).
 -define(DEF_HTTP_CACHE,               false).
 -define(DEF_HTTP_MAX_KEEPALIVE,       1024).
 -define(DEF_CACHE_WORKERS,            64).
@@ -358,6 +359,7 @@
           headers_config_file = []     :: string(),       %% HTTP custom header configuration file path
           timeout_for_header           :: pos_integer(),  %% Timeout for reading header
           timeout_for_body             :: pos_integer(),  %% Timeout for reading body
+          sending_chunk_len = 0        :: pos_integer(),  %% sending chunk length
           %% for cache
           cache_method                 :: cache_method(), %% cahce method: [http | inner]
           cache_workers = 0            :: pos_integer(),  %% number of chache-fun's workers
@@ -374,7 +376,7 @@
           max_chunked_objs = 0         :: pos_integer(),  %% max chunked objects
           max_len_of_obj = 0           :: pos_integer(),  %% max length a object (byte)
           chunked_obj_len = 0          :: pos_integer(),  %% chunked object length for large object (byte)
-          reading_chunked_obj_len = 0  :: pos_integer(),  %% creading hunked object length for large object (byte)
+          reading_chunked_obj_len = 0  :: pos_integer(),  %% reading chunked object length for large object (byte)
           threshold_of_chunk_len = 0   :: pos_integer()   %% threshold of chunk length for large object (byte)
          }).
 
@@ -390,6 +392,7 @@
           custom_header_settings     :: list() | undefined,     %% http custom header settings
           timeout_for_header         :: pos_integer(),          %% Timeout for reading header
           timeout_for_body           :: pos_integer(),          %% Timeout for reading body
+          sending_chunk_len = 0      :: pos_integer(),          %% sending chunk length
           qs_prefix = <<>>           :: binary() | none,        %% query string
           range_header               :: string(),               %% range header
           has_inner_cache = false    :: boolean(),              %% has inner-cache?

--- a/priv/leo_gateway.conf
+++ b/priv/leo_gateway.conf
@@ -80,7 +80,7 @@ http.max_keepalive = 4096
 ## http.timeout_for_body = 15000
 
 ## HTTP sending chunk length
-## http.sending_chunk_len = 131072
+## http.sending_chunked_obj_len = 5242880
 
 ## Synchronized time of a bucket property (second)
 bucket_prop_sync_interval = 300

--- a/priv/leo_gateway.conf
+++ b/priv/leo_gateway.conf
@@ -79,6 +79,9 @@ http.max_keepalive = 4096
 ## HTTP timeout for reading body
 ## http.timeout_for_body = 15000
 
+## HTTP sending chunk length
+## http.sending_chunk_len = 131072
+
 ## Synchronized time of a bucket property (second)
 bucket_prop_sync_interval = 300
 

--- a/priv/leo_gateway.schema
+++ b/priv/leo_gateway.schema
@@ -230,11 +230,11 @@
 
 %% @doc Timeout for sending chunk length
 {mapping,
- "http.sending_chunk_len",
- "leo_gateway.http.sending_chunk_len",
+ "http.sending_chunked_obj_len",
+ "leo_gateway.http.sending_chunked_obj_len",
  [
   {datatype, integer},
-  {default, 131072}
+  {default, 5242880}
  ]}.
 
 %% @doc Synchronized time of a bucket property (second)

--- a/priv/leo_gateway.schema
+++ b/priv/leo_gateway.schema
@@ -228,6 +228,15 @@
   {default, 15000}
  ]}.
 
+%% @doc Timeout for sending chunk length
+{mapping,
+ "http.sending_chunk_len",
+ "leo_gateway.http.sending_chunk_len",
+ [
+  {datatype, integer},
+  {default, 131072}
+ ]}.
+
 %% @doc Synchronized time of a bucket property (second)
 {mapping,
  "bucket_prop_sync_interval",

--- a/src/leo_gateway_app.erl
+++ b/src/leo_gateway_app.erl
@@ -529,7 +529,7 @@ get_options() ->
     CustomHeaderConf     = leo_misc:get_value('headers_config_file', HttpProp, ?DEF_HTTP_CUSTOM_HEADER_CONF),
     Timeout4Header       = leo_misc:get_value('timeout_for_header',  HttpProp, ?DEF_HTTP_TIMEOUT_FOR_HEADER),
     Timeout4Body         = leo_misc:get_value('timeout_for_body',    HttpProp, ?DEF_HTTP_TIMEOUT_FOR_BODY),
-    SendChunkLen         = leo_misc:get_value('sending_chunk_len',   HttpProp, ?DEF_HTTP_SEND_CHUNK_LEN),
+    SendChunkLen         = leo_misc:get_value('sending_chunked_obj_len',   HttpProp, ?DEF_HTTP_SEND_CHUNK_LEN),
 
     %% Retrieve cache-related properties:
     CacheProp = ?env_cache_properties(),
@@ -589,7 +589,7 @@ get_options() ->
                                 headers_config_file      = CustomHeaderConf,
                                 timeout_for_header       = Timeout4Header,
                                 timeout_for_body         = Timeout4Body,
-                                sending_chunk_len        = SendChunkLen,
+                                sending_chunked_obj_len  = SendChunkLen,
                                 cache_method             = CacheMethod,
                                 cache_workers            = CacheWorkers,
                                 cache_ram_capacity       = CacheRAMCapacity,

--- a/src/leo_gateway_app.erl
+++ b/src/leo_gateway_app.erl
@@ -529,6 +529,7 @@ get_options() ->
     CustomHeaderConf     = leo_misc:get_value('headers_config_file', HttpProp, ?DEF_HTTP_CUSTOM_HEADER_CONF),
     Timeout4Header       = leo_misc:get_value('timeout_for_header',  HttpProp, ?DEF_HTTP_TIMEOUT_FOR_HEADER),
     Timeout4Body         = leo_misc:get_value('timeout_for_body',    HttpProp, ?DEF_HTTP_TIMEOUT_FOR_BODY),
+    SendChunkLen         = leo_misc:get_value('sending_chunk_len',   HttpProp, ?DEF_HTTP_SEND_CHUNK_LEN),
 
     %% Retrieve cache-related properties:
     CacheProp = ?env_cache_properties(),
@@ -588,6 +589,7 @@ get_options() ->
                                 headers_config_file      = CustomHeaderConf,
                                 timeout_for_header       = Timeout4Header,
                                 timeout_for_body         = Timeout4Body,
+                                sending_chunk_len        = SendChunkLen,
                                 cache_method             = CacheMethod,
                                 cache_workers            = CacheWorkers,
                                 cache_ram_capacity       = CacheRAMCapacity,
@@ -614,6 +616,7 @@ get_options() ->
     ?info("start/3", "http custom header config: ~p",[CustomHeaderConf]),
     ?info("start/3", "timeout for header : ~p",      [Timeout4Header]),
     ?info("start/3", "timeout for body: ~p",         [Timeout4Body]),
+    ?info("start/3", "sending chunk length: ~p",     [SendChunkLen]),
     ?info("start/3", "cache_method: ~p",             [CacheMethod]),
     ?info("start/3", "cache workers: ~p",            [CacheWorkers]),
     ?info("start/3", "cache ram capacity: ~p",       [CacheRAMCapacity]),

--- a/src/leo_gateway_rest_api.erl
+++ b/src/leo_gateway_rest_api.erl
@@ -190,6 +190,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, _CustomHeaderSet
                                      chunked_obj_len   = Props#http_options.chunked_obj_len,
                                      timeout_for_header      = Props#http_options.timeout_for_header,
                                      timeout_for_body        = Props#http_options.timeout_for_body,
+                                     sending_chunk_len       = Props#http_options.sending_chunk_len,
                                      reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                                      threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len},
             handle_2(Req, HTTPMethod, Path, ReqParams, State);

--- a/src/leo_gateway_rest_api.erl
+++ b/src/leo_gateway_rest_api.erl
@@ -190,7 +190,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, _CustomHeaderSet
                                      chunked_obj_len   = Props#http_options.chunked_obj_len,
                                      timeout_for_header      = Props#http_options.timeout_for_header,
                                      timeout_for_body        = Props#http_options.timeout_for_body,
-                                     sending_chunk_len       = Props#http_options.sending_chunk_len,
+                                     sending_chunked_obj_len = Props#http_options.sending_chunked_obj_len,
                                      reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                                      threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len},
             handle_2(Req, HTTPMethod, Path, ReqParams, State);

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -527,7 +527,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, CustomHeaderSett
                              custom_header_settings  = CustomHeaderSettings,
                              timeout_for_header      = Props#http_options.timeout_for_header,
                              timeout_for_body        = Props#http_options.timeout_for_body,
-                             sending_chunk_len       = Props#http_options.sending_chunk_len,
+                             sending_chunked_obj_len = Props#http_options.sending_chunked_obj_len,
                              reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                              threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len}),
     AuthRet = auth(Req_2, HTTPMethod, Path_1, TokenLen, ReqParams),

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -527,6 +527,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, CustomHeaderSett
                              custom_header_settings  = CustomHeaderSettings,
                              timeout_for_header      = Props#http_options.timeout_for_header,
                              timeout_for_body        = Props#http_options.timeout_for_body,
+                             sending_chunk_len       = Props#http_options.sending_chunk_len,
                              reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                              threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len}),
     AuthRet = auth(Req_2, HTTPMethod, Path_1, TokenLen, ReqParams),

--- a/src/leo_large_object_get_handler.erl
+++ b/src/leo_large_object_get_handler.erl
@@ -51,7 +51,7 @@
           key = <<>>            :: binary(),
           socket = undefined    :: any(),
           transport = undefined :: undefined | module(),
-          sending_chunk_len     :: pos_integer(),
+          sending_chunked_obj_len :: pos_integer(),
           iterator              :: leo_large_object_commons:iterator()
          }).
 
@@ -63,7 +63,7 @@
           reference  :: reference(),
           transport  :: any(),
           socket     :: any(),
-          sending_chunk_len :: pos_integer()
+          sending_chunked_obj_len :: pos_integer()
          }).
 
 
@@ -103,8 +103,8 @@ get(Pid, TotalOfChunkedObjs, Req, Meta) ->
 init([Key, Transport, Socket, SendChunkLen]) ->
     State = #state{key = Key,
                    transport = Transport,
-                   socket = Socket,
-                   sending_chunk_len = SendChunkLen
+                   socket    = Socket,
+                   sending_chunked_obj_len = SendChunkLen
                   },
     {ok, State}.
 
@@ -112,7 +112,7 @@ handle_call(stop, _From, State) ->
     {stop, normal, ok, State};
 
 handle_call({get, TotalOfChunkedObjs, Req, Meta}, _From,
-            #state{key = Key, transport = Transport, socket = Socket, sending_chunk_len = SendChunkLen} = State) ->
+            #state{key = Key, transport = Transport, socket = Socket, sending_chunked_obj_len = SendChunkLen} = State) ->
     Ref_1 = case catch leo_cache_api:put_begin_tran(Key) of
                 {ok, Ref} -> Ref;
                 _ -> undefined
@@ -124,7 +124,7 @@ handle_call({get, TotalOfChunkedObjs, Req, Meta}, _From,
                                                       reference = Ref_1,
                                                       transport = Transport,
                                                       socket = Socket,
-                                                      sending_chunk_len = SendChunkLen}),
+                                                      sending_chunked_obj_len = SendChunkLen}),
     case Reply of
         {ok, _Req} ->
             CacheMeta = #cache_meta{
@@ -170,7 +170,7 @@ handle_loop(Index, TotalChunkObjs, #req_info{key = AcctualKey,
                                              reference = Ref,
                                              socket    = Socket,
                                              transport = Transport,
-                                             sending_chunk_len = SendChunkLen
+                                             sending_chunked_obj_len = SendChunkLen
                                             } = ReqInfo) ->
     IndexBin = list_to_binary(integer_to_list(Index + 1)),
     Key_1 = << ChunkObjKey/binary,


### PR DESCRIPTION
### Problem Description
Current Implementation of sending object to client would catch a problem if the transfer rate is too low.
in `leo_gateway` a chunk is sent at once with `ranch_tcp:send/2` has a send timeout option which defaults to 30 seconds. In other words, if the chunk could not be sent within the timeout, the transfer would fail.

With default value of chunks size (5MB) and timeout (30 seconds), if the transfer rate is lower than 167KB/s, the send would fail with timeout.

### Proposed Solution
As a result, this PR (together with the PR in `leo_commons`) proposes to add a layer to break down object transfer to smaller chunks. 

The sending chunk size is configurable in `leo_gateway.conf` as `http.sending_chunk_len = 131072`

The default value is 128KB, implying a 4KB/s lower bound.

### Related Library PR
https://github.com/leo-project/leo_commons/pull/6

### Related Issue
https://github.com/leo-project/leofs/issues/429