### PR TITLE
Return complete Object List under Bucket when Delimiter is not specified

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -100,6 +100,8 @@
 -define(HTTP_ST_SERVICE_UNAVAILABLE, 503).
 -define(HTTP_ST_GATEWAY_TIMEOUT,     504).
 
+-define(HTTP_MAXKEYS_LIMIT,          1000).
+
 -define(CACHE_HTTP,  'http').
 -define(CACHE_INNER, 'inner').
 -type(cache_method() :: ?CACHE_HTTP | ?CACHE_INNER).

--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -85,6 +85,7 @@
 -define(HTTP_QS_BIN_MARKER,      <<"marker">>).
 -define(HTTP_QS_BIN_MAXKEYS,     <<"max-keys">>).
 -define(HTTP_QS_BIN_MULTI_DELETE,<<"delete">>).
+-define(HTTP_QS_BIN_DELIMITER,   <<"delimiter">>).
 
 -define(HTTP_ST_OK,                  200).
 -define(HTTP_ST_NO_CONTENT,          204).

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -206,10 +206,15 @@ get_bucket(Req, Key, #req_params{access_key_id = AccessKeyId,
                                end
                        end,
     MaxKeys = case cowboy_req:qs_val(?HTTP_QS_BIN_MAXKEYS, Req) of
-                  {undefined, _} -> 1000;
+                  {undefined, _} -> ?HTTP_MAXKEYS_LIMIT;
                   {Val_2,     _} ->
                       try
-                          list_to_integer(binary_to_list(Val_2))
+                          case list_to_integer(binary_to_list(Val_2)) of
+                              MaxKeys1 when MaxKeys1 > ?HTTP_MAXKEYS_LIMIT ->
+                                  ?HTTP_MAXKEYS_LIMIT;
+                              MaxKeys1 ->
+                                  MaxKeys1
+                          end
                       catch _:_ ->
                           badarg
                       end

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -209,12 +209,8 @@ get_bucket(Req, Key, #req_params{access_key_id = AccessKeyId,
                   {undefined, _} -> ?HTTP_MAXKEYS_LIMIT;
                   {Val_2,     _} ->
                       try
-                          case list_to_integer(binary_to_list(Val_2)) of
-                              MaxKeys1 when MaxKeys1 > ?HTTP_MAXKEYS_LIMIT ->
-                                  ?HTTP_MAXKEYS_LIMIT;
-                              MaxKeys1 ->
-                                  MaxKeys1
-                          end
+                          MaxKeys1 = binary_to_integer(Val_2),
+                          erlang:min(MaxKeys1, ?HTTP_MAXKEYS_LIMIT
                       catch _:_ ->
                           badarg
                       end


### PR DESCRIPTION
### Description
When user does not specify `Delimiter`, complete object list under the bucket should be returned

### Related Issue
https://github.com/leo-project/leofs/issues/367