### PR TITLE
Switched to leo_net:chunked_send for 1.4

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -117,6 +117,7 @@
 -define(DEF_HTTP_CUSTOM_HEADER_CONF,  "./http_custom_header.conf").
 -define(DEF_HTTP_TIMEOUT_FOR_HEADER,  5000).
 -define(DEF_HTTP_TIMEOUT_FOR_BODY,    15000).
+-define(DEF_HTTP_SEND_CHUNK_LEN,      5242880).
 -define(DEF_HTTP_CACHE,               false).
 -define(DEF_HTTP_MAX_KEEPALIVE,       1024).
 -define(DEF_CACHE_WORKERS,            64).
@@ -414,6 +415,7 @@
           headers_config_file = []     :: string(),       %% HTTP custom header configuration file path
           timeout_for_header           :: pos_integer(),  %% Timeout for reading header
           timeout_for_body             :: pos_integer(),  %% Timeout for reading body
+          sending_chunked_obj_len = 0  :: pos_integer(),  %% sending chunk length
           %% for cache
           cache_method                 :: cache_method(), %% cahce method: [http | inner]
           cache_workers = 0            :: pos_integer(),  %% number of chache-fun's workers
@@ -430,7 +432,7 @@
           max_chunked_objs = 0         :: pos_integer(),  %% max chunked objects
           max_len_of_obj = 0           :: pos_integer(),  %% max length a object (byte)
           chunked_obj_len = 0          :: pos_integer(),  %% chunked object length for large object (byte)
-          reading_chunked_obj_len = 0  :: pos_integer(),  %% creading hunked object length for large object (byte)
+          reading_chunked_obj_len = 0  :: pos_integer(),  %% reading chunked object length for large object (byte)
           threshold_of_chunk_len = 0   :: pos_integer()   %% threshold of chunk length for large object (byte)
          }).
 
@@ -446,6 +448,7 @@
           custom_header_settings     :: list() | undefined,     %% http custom header settings
           timeout_for_header         :: pos_integer(),          %% Timeout for reading header
           timeout_for_body           :: pos_integer(),          %% Timeout for reading body
+          sending_chunked_obj_len    :: pos_integer(),          %% sending chunk length
           qs_prefix = <<>>           :: binary() | none,        %% query string
           range_header               :: string(),               %% range header
           has_inner_cache = false    :: boolean(),              %% has inner-cache?
@@ -468,6 +471,12 @@
           transfer_decode_state     :: #aws_chunk_decode_state{} | undefined    %% transfer decode state
          }).
 
+-record(transport_record, {
+          transport :: module(),
+          socket    :: inet:socket(),
+          sending_chunked_obj_len :: pos_integer()
+         }).
+
 -record(cache, {
           etag         = 0    :: non_neg_integer(),   %% actual value is checksum
           mtime        = 0    :: non_neg_integer(),   %% gregorian_seconds
@@ -481,5 +490,6 @@
           expire          = 0  :: integer(),          %% specified per sec
           max_content_len = 0  :: integer(),          %% No cache if Content-Length of a response header was &gt this
           content_types   = [] :: list() | undefined, %% like ["image/png", "image/gif", "image/jpeg"]
-          path_patterns   = [] :: list() | undefined  %% compiled regular expressions
+          path_patterns   = [] :: list() | undefined, %% compiled regular expressions
+          sending_chunked_obj_len = 0 :: pos_integer()%% sending chunk length
          }).

--- a/priv/leo_gateway.conf
+++ b/priv/leo_gateway.conf
@@ -79,6 +79,9 @@ http.max_keepalive = 4096
 ## HTTP timeout for reading body
 ## http.timeout_for_body = 15000
 
+## HTTP sending chunk length
+### http.sending_chunked_obj_len = 5242880
+
 ## Synchronized time of a bucket property (second)
 bucket_prop_sync_interval = 300
 

--- a/priv/leo_gateway.schema
+++ b/priv/leo_gateway.schema
@@ -228,6 +228,15 @@
   {default, 15000}
  ]}.
 
+%% @doc Sending chunk length
+{mapping,
+ "http.sending_chunked_obj_len",
+ "leo_gateway.http.sending_chunked_obj_len",
+ [
+  {datatype, integer},
+  {default, 5242880}
+ ]}.
+
 %% @doc Synchronized time of a bucket property (second)
 {mapping,
  "bucket_prop_sync_interval",

--- a/rebar.config
+++ b/rebar.config
@@ -23,6 +23,7 @@
 {require_otp_vsn, "R16B*|17"}.
 
 {deps, [
+        {leo_tran,              ".*", {git, "https://github.com/leo-project/leo_tran.git",              {branch, "develop"}}},
         {leo_cache,             ".*", {git, "https://github.com/leo-project/leo_cache.git",             {branch, "1.4"}}},
         {leo_commons,           ".*", {git, "https://github.com/leo-project/leo_commons.git",           {tag, "1.1.6"}}},
         {leo_logger,            ".*", {git, "https://github.com/leo-project/leo_logger.git",            {tag, "1.2.1"}}},

--- a/src/leo_gateway_app.erl
+++ b/src/leo_gateway_app.erl
@@ -530,6 +530,7 @@ get_options() ->
     CustomHeaderConf     = leo_misc:get_value('headers_config_file', HttpProp, ?DEF_HTTP_CUSTOM_HEADER_CONF),
     Timeout4Header       = leo_misc:get_value('timeout_for_header',  HttpProp, ?DEF_HTTP_TIMEOUT_FOR_HEADER),
     Timeout4Body         = leo_misc:get_value('timeout_for_body',    HttpProp, ?DEF_HTTP_TIMEOUT_FOR_BODY),
+    SendChunkLen         = leo_misc:get_value('sending_chunked_obj_len',   HttpProp, ?DEF_HTTP_SEND_CHUNK_LEN),
 
     %% Retrieve cache-related properties:
     CacheProp = ?env_cache_properties(),
@@ -589,6 +590,7 @@ get_options() ->
                                 headers_config_file      = CustomHeaderConf,
                                 timeout_for_header       = Timeout4Header,
                                 timeout_for_body         = Timeout4Body,
+                                sending_chunked_obj_len  = SendChunkLen,
                                 cache_method             = CacheMethod,
                                 cache_workers            = CacheWorkers,
                                 cache_ram_capacity       = CacheRAMCapacity,
@@ -615,6 +617,7 @@ get_options() ->
     ?info("start/3", "http custom header config: ~p",[CustomHeaderConf]),
     ?info("start/3", "timeout for header : ~p",      [Timeout4Header]),
     ?info("start/3", "timeout for body: ~p",         [Timeout4Body]),
+    ?info("start/3", "sending chunk length: ~p",     [SendChunkLen]),
     ?info("start/3", "cache_method: ~p",             [CacheMethod]),
     ?info("start/3", "cache workers: ~p",            [CacheWorkers]),
     ?info("start/3", "cache ram capacity: ~p",       [CacheRAMCapacity]),

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -50,7 +50,6 @@
           transfer_decode_state:: #aws_chunk_decode_state{}
          }).
 
-
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
@@ -65,6 +64,7 @@ start(#http_options{handler                = Handler,
                     max_keepalive          = MaxKeepAlive,
                     headers_config_file    = CustomHeaderConf,
                     timeout_for_header     = Timeout4Header,
+                    sending_chunked_obj_len= SendChunkLen,
                     cache_method           = CacheMethod,
                     cache_expire           = CacheExpire,
                     cache_max_content_len  = CacheMaxContentLen,
@@ -98,7 +98,8 @@ start(#http_options{handler                = Handler,
                      CacheCondition = #cache_condition{expire          = CacheExpire,
                                                        max_content_len = CacheMaxContentLen,
                                                        content_types   = CachableContentTypes,
-                                                       path_patterns   = CachablePathPatterns},
+                                                       path_patterns   = CachablePathPatterns,
+                                                       sending_chunked_obj_len = SendChunkLen},
                      [{env,        [{dispatch, Dispatch}]},
                       {max_keepalive, MaxKeepAlive},
                       {onrequest,     Handler:onrequest(CacheCondition)},
@@ -135,28 +136,29 @@ start(Sup, Options) ->
 %%
 -spec(onrequest(#cache_condition{}, function()) ->
              any()).
-onrequest(#cache_condition{expire = Expire}, FunGenKey) ->
+onrequest(#cache_condition{expire = Expire, sending_chunked_obj_len = SendChunkLen}, FunGenKey) ->
     fun(Req) ->
             Method = cowboy_req:get(method, Req),
-            onrequest_1(Method, Req, Expire, FunGenKey)
+            onrequest_1(Method, Req, Expire, FunGenKey, SendChunkLen)
     end.
 
-onrequest_1(?HTTP_GET, Req, Expire, FunGenKey) ->
+onrequest_1(?HTTP_GET, Req, Expire, FunGenKey, SendChunkLen) ->
     {_Bucket, Key} = FunGenKey(Req),
     Ret = (catch leo_cache_api:get(Key)),
-    onrequest_2(Req, Expire, Key, Ret);
-onrequest_1(_, Req,_,_) ->
+    onrequest_2(Req, Expire, Key, Ret, SendChunkLen);
+onrequest_1(_, Req,_,_,_) ->
     Req.
 
-onrequest_2(Req,_Expire,_Key, not_found) ->
+onrequest_2(Req,_Expire,_Key, not_found, _) ->
     Req;
-onrequest_2(Req,_Expire,_Key, {'EXIT', _Cause}) ->
+onrequest_2(Req,_Expire,_Key, {'EXIT', _Cause}, _) ->
     Req;
-onrequest_2(Req, Expire, Key, {ok, CachedObj}) ->
+onrequest_2(Req, Expire, Key, {ok, CachedObj}, SendChunkLen) ->
     #cache{mtime        = MTime,
            content_type = ContentType,
            etag         = Checksum,
-           body         = Body} = binary_to_term(CachedObj),
+           body         = Body,
+           size         = Size} = binary_to_term(CachedObj),
 
     Now = leo_date:now(),
     Diff = Now - MTime,
@@ -185,7 +187,10 @@ onrequest_2(Req, Expire, Key, {ok, CachedObj}) ->
                     {ok, Req2} = ?reply_not_modified(Header, Req),
                     Req2;
                 _ ->
-                    {ok, Req2} = ?reply_ok([?SERVER_HEADER], Body, Req),
+                    BodyFunc = fun(Socket, Transport) ->
+                                       leo_net:chunked_send(Transport, Socket, Body, SendChunkLen)
+                               end,
+                    {ok, Req2} = ?reply_ok([?SERVER_HEADER], {Size, BodyFunc}, Req),
                     Req2
             end
     end.
@@ -239,7 +244,8 @@ onresponse(#cache_condition{expire = Expire} = Config, FunGenKey) ->
              {ok, cowboy_req:req()}).
 get_object(Req, Key, #req_params{bucket                 = Bucket,
                                  custom_header_settings = CustomHeaderSettings,
-                                 has_inner_cache        = HasInnerCache}) ->
+                                 has_inner_cache        = HasInnerCache,
+                                 sending_chunked_obj_len= SendChunkLen}) ->
     case leo_gateway_rpc_handler:get(Key) of
         %% For regular case (NOT a chunked object)
         {ok, #?METADATA{cnumber = 0} = Meta, RespObject} ->
@@ -264,7 +270,10 @@ get_object(Req, Key, #req_params{bucket                 = Bucket,
                        {?HTTP_HEAD_RESP_LAST_MODIFIED, ?http_date(Meta#?METADATA.timestamp)}],
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
             Headers2 = Headers ++ CustomHeaders,
-            ?reply_ok(Headers2, RespObject, Req);
+            BodyFunc = fun(Socket, Transport) ->
+                               leo_net:chunked_send(Transport, Socket, RespObject, SendChunkLen)
+                       end,
+            ?reply_ok(Headers2, {Meta#?METADATA.dsize, BodyFunc}, Req);
 
         %% For a chunked object.
         {ok, #?METADATA{cnumber = TotalChunkedObjs} = Meta, _RespObject} ->
@@ -276,7 +285,9 @@ get_object(Req, Key, #req_params{bucket                 = Bucket,
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
             Headers2 = Headers ++ CustomHeaders,
             BodyFunc = fun(Socket, Transport) ->
-                               {ok, Pid} = leo_large_object_get_handler:start_link({Key, Transport, Socket}),
+                               {ok, Pid} = leo_large_object_get_handler:start_link({Key, #transport_record{transport = Transport, 
+                                                                                                           socket = Socket, 
+                                                                                                           sending_chunked_obj_len = SendChunkLen}}),
                                try
                                    leo_large_object_get_handler:get(Pid, TotalChunkedObjs, Req, Meta),
                                    ok
@@ -304,7 +315,8 @@ get_object(Req, Key, #req_params{bucket                 = Bucket,
 -spec(get_object_with_cache(cowboy_req:req(), binary(), #cache{}, #req_params{}) ->
              {ok, cowboy_req:req()}).
 get_object_with_cache(Req, Key, CacheObj, #req_params{bucket                 = Bucket,
-                                                      custom_header_settings = CustomHeaderSettings}) ->
+                                                      custom_header_settings = CustomHeaderSettings,
+                                                      sending_chunked_obj_len= SendChunkLen}) ->
     case leo_gateway_rpc_handler:get(Key, CacheObj#cache.etag) of
         %% HIT: get an object from disc-cache
         {ok, match} when CacheObj#cache.file_path /= [] ->
@@ -317,7 +329,7 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket                 = B
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
             Headers2 = Headers ++ CustomHeaders,
             BodyFunc = fun(Socket, _Transport) ->
-                               file:sendfile(CacheObj#cache.file_path, Socket),
+                               file:sendfile(CacheObj#cache.file_path, Socket, 0, 0, [{chunk_size, SendChunkLen}]),
                                ok
                        end,
             cowboy_req:reply(?HTTP_ST_OK, Headers2, {CacheObj#cache.size, BodyFunc}, Req);
@@ -332,7 +344,10 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket                 = B
                        {?HTTP_HEAD_X_FROM_CACHE,       <<"True/via memory">>}],
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
             Headers2 = Headers ++ CustomHeaders,
-            ?reply_ok(Headers2, CacheObj#cache.body, Req);
+            BodyFunc = fun(Socket, Transport) ->
+                               leo_net:chunked_send(Transport, Socket, CacheObj#cache.body, SendChunkLen)
+                       end,
+            ?reply_ok(Headers2, {CacheObj#cache.size, BodyFunc}, Req);
 
         %% MISS: get an object from storage (small-size)
         {ok, #?METADATA{cnumber = 0} = Meta, RespObject} ->
@@ -352,7 +367,10 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket                 = B
                        {?HTTP_HEAD_RESP_LAST_MODIFIED, ?http_date(Meta#?METADATA.timestamp)}],
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
             Headers2 = Headers ++ CustomHeaders,
-            ?reply_ok(Headers2, RespObject, Req);
+            BodyFunc = fun(Socket, Transport) ->
+                               leo_net:chunked_send(Transport, Socket, RespObject, SendChunkLen)
+                       end,
+            ?reply_ok(Headers2, {Meta#?METADATA.dsize, BodyFunc}, Req);
 
         %% MISS: get an object from storage (large-size)
         {ok, #?METADATA{cnumber = TotalChunkedObjs} = Meta, _RespObject} ->
@@ -364,7 +382,9 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket                 = B
             {ok, CustomHeaders} = leo_nginx_conf_parser:get_custom_headers(Key, CustomHeaderSettings),
             Headers2 = Headers ++ CustomHeaders,
             BodyFunc = fun(Socket, Transport) ->
-                               {ok, Pid} = leo_large_object_get_handler:start_link({Key, Transport, Socket}),
+                               {ok, Pid} = leo_large_object_get_handler:start_link({Key, #transport_record{transport = Transport, 
+                                                                                                           socket = Socket, 
+                                                                                                           sending_chunked_obj_len = SendChunkLen}}),
                                try
                                    leo_large_object_get_handler:get(Pid, TotalChunkedObjs, Req, Meta)
                                after
@@ -780,15 +800,16 @@ head_object(Req, Key, #req_params{bucket = Bucket}) ->
 -spec(range_object(cowboy_req:req(), binary(), #req_params{}) ->
              {ok, cowboy_req:req()}).
 range_object(Req, Key, #req_params{bucket = Bucket,
-                                   range_header = RangeHeader}) ->
+                                   range_header = RangeHeader,
+                                   sending_chunked_obj_len = SendChunkLen}) ->
     Range = cowboy_http:range(RangeHeader),
-    get_range_object(Req, Bucket, Key, Range).
+    get_range_object(Req, Bucket, Key, Range, SendChunkLen).
 
 %% @private
-get_range_object(Req, Bucket, Key, {error, badarg}) ->
+get_range_object(Req, Bucket, Key, {error, badarg}, _) ->
     ?access_log_get(Bucket, Key, 0, ?HTTP_ST_BAD_RANGE),
     ?reply_bad_range([?SERVER_HEADER], Key, <<>>, Req);
-get_range_object(Req, Bucket, Key, {_Unit, Range}) when is_list(Range) ->
+get_range_object(Req, Bucket, Key, {_Unit, Range}, SendChunkLen) when is_list(Range) ->
     case get_body_length(Key, Range) of
         {ok, Length} ->
             case leo_gateway_rpc_handler:head(Key) of
@@ -800,8 +821,10 @@ get_range_object(Req, Bucket, Key, {_Unit, Range}) when is_list(Range) ->
                     Req2 = cowboy_req:set_resp_body_fun(
                              Length,
                              fun(Socket, Transport) ->
-                                     get_range_object_1(Req, Bucket, Key, Range,
-                                                        undefined, Socket, Transport)
+                             get_range_object_1(Req, Bucket, Key, Range, undefined,
+                                                #transport_record{transport = Transport,
+                                                                  socket    = Socket,
+                                                                  sending_chunked_obj_len = SendChunkLen})
                              end,
                              Req),
                     ?reply_partial_content(Header, Req2);
@@ -858,7 +881,8 @@ get_body_length_1(_, _, _) ->
     {error, bad_range}.
 
 %% @private
-get_range_object_1(_Req, _Bucket, _Key, _, {error, _Reason}, Socket, Transport) ->
+get_range_object_1(_Req, _Bucket, _Key, _, {error, _Reason}, #transport_record{socket = Socket,
+                                                                               transport = Transport}) ->
     %% @TODO:
     %%    Transport:close(Socket),
     %%    case Reason of
@@ -870,24 +894,24 @@ get_range_object_1(_Req, _Bucket, _Key, _, {error, _Reason}, Socket, Transport) 
     %%            ?reply_internal_error_without_body([?SERVER_HEADER], Req)
     %%    end;
     Transport:close(Socket);
-get_range_object_1(Req,_Bucket,_Key, [], _, _Socket, _Transport) ->
+get_range_object_1(Req,_Bucket,_Key, [], _, _TransportRec) ->
     {ok, Req};
-get_range_object_1(Req, Bucket, Key, [{Start, infinity}|Rest], _, Socket, Transport) ->
-    Ret = get_range_object_2(Req, Bucket, Key, Start, 0, Socket, Transport),
-    get_range_object_1(Req, Bucket, Key, Rest, Ret, Socket, Transport);
-get_range_object_1(Req, Bucket, Key, [{Start, End}|Rest], _, Socket, Transport) ->
-    Ret = get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport),
-    get_range_object_1(Req, Bucket, Key, Rest, Ret, Socket, Transport);
-get_range_object_1(Req, Bucket, Key, [End|Rest], _, Socket, Transport) ->
-    Ret = get_range_object_2(Req, Bucket, Key, 0, End, Socket, Transport),
-    get_range_object_1(Req, Bucket, Key, Rest, Ret, Socket, Transport).
+get_range_object_1(Req, Bucket, Key, [{Start, infinity}|Rest], _, TransportRec) ->
+    Ret = get_range_object_2(Req, Bucket, Key, Start, 0, TransportRec),
+    get_range_object_1(Req, Bucket, Key, Rest, Ret, TransportRec);
+get_range_object_1(Req, Bucket, Key, [{Start, End}|Rest], _, TransportRec) ->
+    Ret = get_range_object_2(Req, Bucket, Key, Start, End, TransportRec),
+    get_range_object_1(Req, Bucket, Key, Rest, Ret, TransportRec);
+get_range_object_1(Req, Bucket, Key, [End|Rest], _, TransportRec) ->
+    Ret = get_range_object_2(Req, Bucket, Key, 0, End, TransportRec),
+    get_range_object_1(Req, Bucket, Key, Rest, Ret, TransportRec).
 
 %% @private
-get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport) ->
+get_range_object_2(Req, Bucket, Key, Start, End, TransportRec) ->
     case leo_gateway_rpc_handler:head(Key) of
         {ok, #?METADATA{del = 0,
                         cnumber = 0}} ->
-            get_range_object_small(Req, Bucket, Key, Start, End, Socket, Transport);
+            get_range_object_small(Req, Bucket, Key, Start, End, TransportRec);
         {ok, #?METADATA{del = 0,
                         cnumber = N,
                         dsize = ObjectSize,
@@ -911,7 +935,7 @@ get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport) ->
                 end,
             get_range_object_large(Req, Bucket, Key,
                                    NewStartPos, NewEndPos, N, Index_1, CurPos_1,
-                                   Socket, Transport);
+                                   TransportRec);
         Error ->
             Error
     end.
@@ -919,14 +943,16 @@ get_range_object_2(Req, Bucket, Key, Start, End, Socket, Transport) ->
 
 %% @doc Retrieve the small object
 %% @private
-get_range_object_small(_Req, Bucket, Key, Start, End, Socket, Transport) ->
+get_range_object_small(_Req, Bucket, Key, Start, End, #transport_record{transport = Transport,
+                                                                        socket    = Socket,
+                                                                        sending_chunked_obj_len = SendChunkLen}) ->
     case leo_gateway_rpc_handler:get(Key, Start, End) of
         {ok, _Meta, <<>>} ->
             ?access_log_get(Bucket, Key, 0, ?HTTP_ST_OK),
             ok;
         {ok, _Meta, Bin} ->
             ?access_log_get(Bucket, Key, byte_size(Bin), ?HTTP_ST_OK),
-            case Transport:send(Socket, Bin) of
+            case leo_net:chunked_send(Transport, Socket, Bin, SendChunkLen) of
                 ok ->
                     ok;
                 {error, Cause} ->
@@ -958,13 +984,13 @@ calc_pos(StartPos, EndPos, _ObjectSize) ->
 
 %% @doc Retrieve the large object
 %% @private
-get_range_object_large(_Req,_Bucket,_Key,_Start,_End, _Total, _Index, {error, _} = Error, _Socket, _Transport) ->
+get_range_object_large(_Req,_Bucket,_Key,_Start,_End, _Total, _Index, {error, _} = Error, _TransportRec) ->
     Error;
-get_range_object_large(_Req,_Bucket,_Key,_Start,_End, Total, Total, CurPos, _Socket, _Transport) ->
+get_range_object_large(_Req,_Bucket,_Key,_Start,_End, Total, Total, CurPos, _TransportRec) ->
     {ok, CurPos};
-get_range_object_large(_Req,_Bucket,_Key,_Start, End,_Total,_Index, CurPos, _Socket, _Transport) when CurPos > End ->
+get_range_object_large(_Req,_Bucket,_Key,_Start, End,_Total,_Index, CurPos, _TransportRec) when CurPos > End ->
     {ok, CurPos};
-get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos, Socket, Transport) ->
+get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos, TransportRec) ->
     IndexBin = list_to_binary(integer_to_list(Index + 1)),
     Key2 = << Key/binary, ?DEF_SEPARATOR/binary, IndexBin/binary >>,
 
@@ -972,13 +998,13 @@ get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos, Sock
         {ok, #?METADATA{cnumber = 0,
                         dsize = CS}} ->
             %% get and chunk an object
-            NewPos = send_chunk(Req, Bucket, Key2, Start, End, CurPos, CS, Socket, Transport),
-            get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos, Socket, Transport);
+            NewPos = send_chunk(Req, Bucket, Key2, Start, End, CurPos, CS, TransportRec),
+            get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos, TransportRec);
 
         {ok, #?METADATA{cnumber = GrandChildNum}} ->
-            case get_range_object_large(Req, Bucket, Key2, Start, End, GrandChildNum, 0, CurPos, Socket, Transport) of
+            case get_range_object_large(Req, Bucket, Key2, Start, End, GrandChildNum, 0, CurPos, TransportRec) of
                 {ok, NewPos} ->
-                    get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos, Socket, Transport);
+                    get_range_object_large(Req, Bucket, Key, Start, End, Total, Index + 1, NewPos, TransportRec);
                 {error, Cause} ->
                     {error, Cause}
             end;
@@ -988,19 +1014,19 @@ get_range_object_large( Req, Bucket, Key, Start, End, Total, Index, CurPos, Sock
 
 %% @doc
 %% @private
-send_chunk(_Req,_,_Key, Start,_End, CurPos,
-           ChunkSize, _Socket, _Transport) when (CurPos + ChunkSize - 1) < Start ->
+send_chunk(_Req,_,_Key, Start,_End, CurPos, ChunkSize, _TransportRec) when (CurPos + ChunkSize - 1) < Start ->
     %% skip proc
     CurPos + ChunkSize;
-send_chunk(_Req,_Bucket, Key, Start, End, CurPos,
-           ChunkSize, Socket, Transport) when CurPos >= Start andalso
-                                              (CurPos + ChunkSize - 1) =< End ->
+send_chunk(_Req,_Bucket, Key, Start, End, CurPos, ChunkSize, #transport_record{transport = Transport,
+                                                                               socket    = Socket,
+                                                                               sending_chunked_obj_len = SendChunkLen}) when CurPos >= Start andalso
+                                                                                                                             (CurPos + ChunkSize - 1) =< End ->
     %% whole get
     case leo_gateway_rpc_handler:get(Key) of
         {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand children
             %% ?access_log_get(Bucket, Key, ChunkSize, ?HTTP_ST_OK),
-            case Transport:send(Socket, Bin) of
+            case leo_net:chunked_send(Transport, Socket, Bin, SendChunkLen) of
                 ok ->
                     CurPos + ChunkSize;
                 {error, Cause} ->
@@ -1009,7 +1035,9 @@ send_chunk(_Req,_Bucket, Key, Start, End, CurPos,
         Error ->
             Error
     end;
-send_chunk(_Req, _Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport) ->
+send_chunk(_Req, _Bucket, Key, Start, End, CurPos, ChunkSize, #transport_record{transport = Transport,
+                                                                                socket    = Socket,
+                                                                                sending_chunked_obj_len = SendChunkLen}) ->
     %% partial get
     StartPos = case Start =< CurPos of
                    true -> 0;
@@ -1025,7 +1053,7 @@ send_chunk(_Req, _Bucket, Key, Start, End, CurPos, ChunkSize, Socket, Transport)
         {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand childs
             %% ?access_log_get(Bucket, Key, ChunkSize, ?HTTP_ST_OK),
-            case Transport:send(Socket, Bin) of
+            case leo_net:chunked_send(Transport, Socket, Bin, SendChunkLen) of
                 ok ->
                     CurPos + ChunkSize;
                 {error, Cause} ->

--- a/src/leo_gateway_rest_api.erl
+++ b/src/leo_gateway_rest_api.erl
@@ -188,6 +188,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, _CustomHeaderSet
                                      chunked_obj_len   = Props#http_options.chunked_obj_len,
                                      timeout_for_header      = Props#http_options.timeout_for_header,
                                      timeout_for_body        = Props#http_options.timeout_for_body,
+                                     sending_chunked_obj_len = Props#http_options.sending_chunked_obj_len,
                                      reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                                      threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len},
             handle_2(Req, HTTPMethod, Path, ReqParams, State);

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -701,6 +701,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers},
                              custom_header_settings  = CustomHeaderSettings,
                              timeout_for_header      = Props#http_options.timeout_for_header,
                              timeout_for_body        = Props#http_options.timeout_for_body,
+                             sending_chunked_obj_len = Props#http_options.sending_chunked_obj_len,
                              reading_chunked_obj_len = Props#http_options.reading_chunked_obj_len,
                              threshold_of_chunk_len  = Props#http_options.threshold_of_chunk_len}),
 


### PR DESCRIPTION
### Problem Description
Current Implementation of sending object to client would catch a problem if the transfer rate is too low.
in `leo_gateway` a chunk is sent at once with `ranch_tcp:send/2` has a send timeout option which defaults to 30 seconds. In other words, if the chunk could not be sent within the timeout, the transfer would fail.

### Proposed Solution
This PR uses `leo_net:chunked_send` to break down the transfer into smaller chunks. With a configurable sending chunk size in `leo_gateway.conf` as `http.sending_chunk_len = 5242880`

### Related Issue
https://github.com/leo-project/leofs/issues/429