### PR TITLE
Added handling for already owned bucket error

### DIFF
--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -761,6 +761,9 @@ handle_2({error, unmatch}, Req,_,Key,_,State) ->
 handle_2({error, not_found}, Req,_,Key,_,State) ->
     {ok, Req_2} = ?reply_not_found([?SERVER_HEADER], Key, <<>>, Req),
     {ok, Req_2, State};
+handle_2({error, already_yours}, Req,_,Key,_,State) ->
+    {ok, Req_2} = ?reply_conflict([?SERVER_HEADER], ?XML_ERROR_CODE_BucketAlreadyOwnedByYou, ?XML_ERROR_MSG_BucketAlreadyOwnedByYou, Key, <<>>, Req),
+    {ok, Req_2, State};
 handle_2({error, _Cause}, Req,_,Key,_,State) ->
     {ok, Req_2} = ?reply_forbidden([?SERVER_HEADER], ?XML_ERROR_CODE_AccessDenied, ?XML_ERROR_MSG_AccessDenied, Key, <<>>, Req),
     {ok, Req_2, State};


### PR DESCRIPTION
### Description
To return more precise error message to user for bucket operations

1. Create an already owned bucket
2. Get an non-existent bucket

### Related Issue
https://github.com/leo-project/leofs/issues/409

### Related PR
https://github.com/leo-project/leo_s3_libs/pull/3
https://github.com/leo-project/leo_gateway/pull/33