### PR TITLE
[leo_gateway] Allow to set cache verification from always to periodic

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -397,6 +397,7 @@
           range_header               :: string(),               %% range header
           has_inner_cache = false    :: boolean(),              %% has inner-cache?
           is_cached = false          :: boolean(),              %% is cached?
+          cache_expire = 0           :: pos_integer(),          %% cache expire time (sec)
           is_dir = false             :: boolean(),              %% is directory?
           is_multi_delete = false    :: boolean(),              %% is multi delete request?
           %% for large-object
@@ -415,6 +416,7 @@
 -record(cache, {
           etag         = 0    :: non_neg_integer(),   %% actual value is checksum
           mtime        = 0    :: non_neg_integer(),   %% gregorian_seconds
+          last_sync    = 0    :: non_neg_integer(),   %% Last sync with Storage
           content_type = <<>> :: binary() | string(), %% from a Content-Type header
           body         = <<>> :: binary(),            %% body (value),
           size         = 0    :: non_neg_integer(),       %% body size

--- a/src/leo_gateway_rest_api.erl
+++ b/src/leo_gateway_rest_api.erl
@@ -185,6 +185,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, _CustomHeaderSet
                                      max_layers        = NumOfMaxLayers,
                                      has_inner_cache   = HasInnerCache,
                                      is_cached         = true,
+                                     cache_expire      = Props#http_options.cache_expire,
                                      max_chunked_objs  = Props#http_options.max_chunked_objs,
                                      max_len_of_obj    = Props#http_options.max_len_of_obj,
                                      chunked_obj_len   = Props#http_options.chunked_obj_len,

--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -519,6 +519,7 @@ handle_1(Req, [{NumOfMinLayers, NumOfMaxLayers}, HasInnerCache, CustomHeaderSett
                              qs_prefix         = Prefix,
                              has_inner_cache   = HasInnerCache,
                              is_cached         = true,
+                             cache_expire      = Props#http_options.cache_expire,
                              is_dir            = IsDir,
                              is_acl            = IsACL,
                              max_chunked_objs  = Props#http_options.max_chunked_objs,


### PR DESCRIPTION
### Description
When using the `inner cache` in `leo_gateway`, ETag of cache is compared with the one in backend `leo_storage` for every cache hit.

The round trip is not favorable for small read intensive workload, users may want to relax the consistency for better performance.

### Proposal
Reference to the expire mechanism in `http cache`, allow the user to choose from "Strictly checked" to "check once 5 minutes" by setting the `cache.cache_expire`

Setting to `0` means checking every time and other values mean check once `x` seconds
