### PR TITLE
Custom Metadata Support #2

### DIFF
--- a/include/leo_http.hrl
+++ b/include/leo_http.hrl
@@ -113,6 +113,7 @@
 -define(HTTP_ST_GATEWAY_TIMEOUT,     504).
 
 -define(HTTP_MAXKEYS_LIMIT,          1000).
+-define(HTTP_METADATA_LIMIT,         2048).
 
 -define(CACHE_HTTP,  'http').
 -define(CACHE_INNER, 'inner').
@@ -163,6 +164,7 @@
 -define(XML_ERROR_CODE_InvalidBucketName, "InvalidBucketName").
 -define(XML_ERROR_CODE_SignatureDoesNotMatch, "SignatureDoesNotMatch").
 -define(XML_ERROR_CODE_RequestTimeTooSkewed, "RequestTimeTooSkewed").
+-define(XML_ERROR_CODE_MetadataTooLarge, "MetadataTooLarge").
 
 %% error messages used in a error response
 -define(XML_ERROR_MSG_EntityTooLarge, "Your proposed upload exceeds the maximum allowed object size.").
@@ -181,6 +183,7 @@
 -define(XML_ERROR_MSG_InvalidBucketName, "The specified bucket is not valid.").
 -define(XML_ERROR_MSG_SignatureDoesNotMatch, "The request signature we calculated does not match the signature you provided. Check your AWS secret access key and signing method.").
 -define(XML_ERROR_MSG_RequestTimeTooSkewed, "The difference between the request time and the server's time is too large.").
+-define(XML_ERROR_MSG_MetadataTooLarge, "Your metadata headers exceed the maximum allowed metadata size.").
 
 %% Macros
 %% - code:200
@@ -263,6 +266,11 @@
         cowboy_req:reply(?HTTP_ST_BAD_REQ, _H,
                          io_lib:format(?XML_ERROR, [?XML_ERROR_CODE_BadDigest,
                                                     ?XML_ERROR_MSG_BadDigest,
+                                                    xmerl_lib:export_text(_Key), _ReqId]), _R)).
+-define(reply_metadata_too_large(_H, _Key, _ReqId, _R),
+        cowboy_req:reply(?HTTP_ST_BAD_REQ, _H,
+                         io_lib:format(?XML_ERROR, [?XML_ERROR_CODE_MetadataTooLarge,
+                                                    ?XML_ERROR_MSG_MetadataTooLarge,
                                                     xmerl_lib:export_text(_Key), _ReqId]), _R)).
 
 -define(http_header(_R, _K),

--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -284,7 +284,8 @@ get_object(Req, Key, #req_params{bucket_name = BucketName,
                                  sending_chunked_obj_len = SendChunkLen}) ->
     case leo_gateway_rpc_handler:get(Key) of
         %% For regular case (NOT a chunked object)
-        {ok, #?METADATA{cnumber = 0} = Meta, RespObject, CMetaBin} ->
+        {ok, #?METADATA{cnumber = 0,
+                        meta = CMetaBin} = Meta, RespObject} ->
             Mime = leo_mime:guess_mime(Key),
 
             case HasInnerCache of
@@ -323,7 +324,8 @@ get_object(Req, Key, #req_params{bucket_name = BucketName,
 
         %% For a chunked object.
         {ok, #?METADATA{cnumber = TotalChunkedObjs,
-                        dsize = ObjLen} = Meta, _RespObject, CMetaBin} ->
+                        dsize = ObjLen,
+                        meta = CMetaBin} = Meta, _RespObject} ->
             Mime = leo_mime:guess_mime(Key),
             Headers = [?SERVER_HEADER,
                        {?HTTP_HEAD_RESP_CONTENT_TYPE, Mime},
@@ -430,7 +432,8 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket_name = BucketName,
             ?reply_ok(Headers2, {CacheObj#cache.size, BodyFunc}, Req);
 
         %% MISS: get an object from storage (small-size)
-        {ok, #?METADATA{cnumber = 0} = Meta, RespObject, CMetaBin} ->
+        {ok, #?METADATA{cnumber = 0,
+                        meta = CMetaBin} = Meta, RespObject} ->
             ?access_log_get(BucketName, Key, Meta#?METADATA.dsize, ?HTTP_ST_OK),
             Mime = leo_mime:guess_mime(Key),
             Val = term_to_binary(#cache{etag = Meta#?METADATA.checksum,
@@ -461,7 +464,8 @@ get_object_with_cache(Req, Key, CacheObj, #req_params{bucket_name = BucketName,
 
         %% MISS: get an object from storage (large-size)
         {ok, #?METADATA{cnumber = TotalChunkedObjs,
-                        dsize = ObjLen} = Meta, _RespObject, CMetaBin} ->
+                        dsize = ObjLen,
+                        meta = CMetaBin} = Meta, _RespObject} ->
             Mime = leo_mime:guess_mime(Key),
             Headers = [?SERVER_HEADER,
                        {?HTTP_HEAD_RESP_CONTENT_TYPE,  Mime},
@@ -870,43 +874,27 @@ delete_object(Req, Key, #req_params{bucket_name = BucketName}) ->
 head_object(Req, Key, #req_params{bucket_name = BucketName}) ->
     case leo_gateway_rpc_handler:head(Key) of
         {ok, #?METADATA{del = 0,
-                        msize = CMetaSize} = Meta} ->
-            CMetaBin = case CMetaSize of
-                           0 ->
-                               <<>>;
+                        meta = CMetaBin} = Meta} ->
+            Timestamp = leo_http:rfc1123_date(Meta#?METADATA.timestamp),
+            ?access_log_head(BucketName, Key, ?HTTP_ST_OK),
+            Headers = [?SERVER_HEADER,
+                       {?HTTP_HEAD_RESP_CONTENT_TYPE, leo_mime:guess_mime(Key)},
+                       {?HTTP_HEAD_RESP_ETAG, ?http_etag(Meta#?METADATA.checksum)},
+                       {?HTTP_HEAD_RESP_CONTENT_LENGTH, erlang:integer_to_list(Meta#?METADATA.dsize)},
+                       {?HTTP_HEAD_RESP_LAST_MODIFIED, Timestamp}],
+            Headers2 = case CMetaBin of
+                           <<>> ->
+                               Headers;
                            _ ->
-                               case leo_gateway_rpc_handler:get(Key) of
-                                   {ok, _, _, Bin} ->
-                                       Bin;
-                                   Ret ->
-                                       Ret
-                               end
+                               CMeta = binary_to_term(CMetaBin),
+                               CMeta ++ Headers
                        end,
-            case CMetaBin of
-                {error, Cause} ->
-                    reply_fun({error, Cause}, head, BucketName, Key, 0, Req);
-                _ ->
-                    Timestamp = leo_http:rfc1123_date(Meta#?METADATA.timestamp),
-                    ?access_log_head(BucketName, Key, ?HTTP_ST_OK),
-                    Headers = [?SERVER_HEADER,
-                               {?HTTP_HEAD_RESP_CONTENT_TYPE, leo_mime:guess_mime(Key)},
-                               {?HTTP_HEAD_RESP_ETAG, ?http_etag(Meta#?METADATA.checksum)},
-                               {?HTTP_HEAD_RESP_CONTENT_LENGTH, erlang:integer_to_list(Meta#?METADATA.dsize)},
-                               {?HTTP_HEAD_RESP_LAST_MODIFIED, Timestamp}],
-                    Headers2 = case CMetaBin of
-                                   <<>> ->
-                                       Headers;
-                                   _ ->
-                                       CMeta = binary_to_term(CMetaBin),
-                                       CMeta ++ Headers
-                               end,
-                    cowboy_req:reply(?HTTP_ST_OK, Headers2, fun() -> void end, Req)
-            end;
+            cowboy_req:reply(?HTTP_ST_OK, Headers2, fun() -> void end, Req);
         {ok, #?METADATA{del = 1}, _} ->
             ?access_log_head(BucketName, Key, ?HTTP_ST_NOT_FOUND),
             ?reply_not_found_without_body([?SERVER_HEADER], Req);
-        {error, Cause2} ->
-            reply_fun({error, Cause2}, head, BucketName, Key, 0, Req)
+        {error, Cause} ->
+            reply_fun({error, Cause}, head, BucketName, Key, 0, Req)
     end.
 
 
@@ -929,46 +917,28 @@ get_range_object(Req, BucketName, Key, {_Unit, Range}, SendChunkLen) when is_lis
         {ok, Length} ->
             case leo_gateway_rpc_handler:head(Key) of
                 {ok, #?METADATA{del = 0,
-                                msize = CMetaSize} = Meta} ->
-                    CMetaBin = case CMetaSize of
-                                   0 ->
-                                       <<>>;
+                                meta = CMetaBin} = Meta}->
+                    Timestamp = leo_http:rfc1123_date(Meta#?METADATA.timestamp),
+                    Headers = [?SERVER_HEADER,
+                               {?HTTP_HEAD_RESP_CONTENT_TYPE, leo_mime:guess_mime(Key)},
+                               {?HTTP_HEAD_RESP_LAST_MODIFIED, Timestamp}],
+                    Headers2 = case CMetaBin of
+                                   <<>> ->
+                                       Headers;
                                    _ ->
-                                       case leo_gateway_rpc_handler:get(Key) of
-                                           {ok, _, _, Bin} ->
-                                               Bin;
-                                           Ret ->
-                                               Ret
-                                       end
+                                       CMeta = binary_to_term(CMetaBin),
+                                       CMeta ++ Headers
                                end,
-                    case CMetaBin of
-                        {error, _Cause} ->
-                            ?access_log_get(BucketName, Key, 0, ?HTTP_ST_INTERNAL_ERROR),
-                            ?reply_internal_error_without_body([?SERVER_HEADER], Req);
-                        _ ->
-
-                            Timestamp = leo_http:rfc1123_date(Meta#?METADATA.timestamp),
-                            Headers = [?SERVER_HEADER,
-                                       {?HTTP_HEAD_RESP_CONTENT_TYPE, leo_mime:guess_mime(Key)},
-                                       {?HTTP_HEAD_RESP_LAST_MODIFIED, Timestamp}],
-                            Headers2 = case CMetaBin of
-                                           <<>> ->
-                                               Headers;
-                                           _ ->
-                                               CMeta = binary_to_term(CMetaBin),
-                                               CMeta ++ Headers
-                                       end,
-                            Req2 = cowboy_req:set_resp_body_fun(
-                                     Length,
-                                     fun(Socket, Transport) ->
-                                             get_range_object_1(Req, BucketName, Key, Range, undefined,
-                                                                #transport_record{transport = Transport,
-                                                                                  socket = Socket,
-                                                                                  sending_chunked_obj_len = SendChunkLen})
-                                     end,
-                                     Req),
-                            ?reply_partial_content(Headers2, Req2)
-                    end;
+                    Req2 = cowboy_req:set_resp_body_fun(
+                             Length,
+                             fun(Socket, Transport) ->
+                                     get_range_object_1(Req, BucketName, Key, Range, undefined,
+                                                        #transport_record{transport = Transport,
+                                                                          socket = Socket,
+                                                                          sending_chunked_obj_len = SendChunkLen})
+                             end,
+                             Req),
+                    ?reply_partial_content(Headers2, Req2);
                 {ok, #?METADATA{del = 1}} ->
                     ?access_log_head(BucketName, Key, ?HTTP_ST_NOT_FOUND),
                     ?reply_not_found_without_body([?SERVER_HEADER], Req);
@@ -1064,10 +1034,10 @@ get_range_object_small(_Req, BucketName, Key, Start, End,
                                          socket = Socket,
                                          sending_chunked_obj_len = SendChunkLen}) ->
     case leo_gateway_rpc_handler:get(Key, Start, End) of
-        {ok, _Meta, <<>>, _} ->
+        {ok, _Meta, <<>>} ->
             ?access_log_get(BucketName, Key, 0, ?HTTP_ST_OK),
             ok;
-        {ok, _Meta, Bin, _} ->
+        {ok, _Meta, Bin} ->
             ?access_log_get(BucketName, Key, byte_size(Bin), ?HTTP_ST_OK),
             case leo_net:chunked_send(Transport, Socket, Bin, SendChunkLen) of
                 ok ->
@@ -1179,7 +1149,7 @@ send_chunk(_Req,_BucketName, Key, Start, End, CurPos, ChunkSize,
        (CurPos + ChunkSize - 1) =< End ->
     %% whole get
     case leo_gateway_rpc_handler:get(Key) of
-        {ok, _Meta, Bin, _} ->
+        {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand children
             %% ?access_log_get(BucketName, Key, ChunkSize, ?HTTP_ST_OK),
             case leo_net:chunked_send(Transport, Socket, Bin, SendChunkLen) of
@@ -1206,9 +1176,9 @@ send_chunk(_Req,_BucketName, Key, Start, End, CurPos, ChunkSize,
                  false -> End - CurPos
              end,
     case leo_gateway_rpc_handler:get(Key, StartPos, EndPos) of
-        {ok, _Meta, <<>>, _} ->
+        {ok, _Meta, <<>>} ->
             CurPos + ChunkSize;
-        {ok, _Meta, Bin, _} ->
+        {ok, _Meta, Bin} ->
             %% @FIXME current impl can't handle a file which consist of grand childs
             %% ?access_log_get(BucketName, Key, ChunkSize, ?HTTP_ST_OK),
             case leo_net:chunked_send(Transport, Socket, Bin, SendChunkLen) of

--- a/src/leo_gateway_rpc_handler.erl
+++ b/src/leo_gateway_rpc_handler.erl
@@ -57,7 +57,7 @@
 %% @doc Retrieve a metadata from the storage-cluster
 %%
 -spec(head(binary()) ->
-             {ok, #?METADATA{}, binary()}|{error, any()}).
+             {ok, #?METADATA{}}|{error, any()}).
 head(Key) ->
     ReqParams = get_request_parameters(head, Key),
     invoke(ReqParams#rpc_params.redundancies,
@@ -69,7 +69,7 @@ head(Key) ->
 %% @doc Retrieve an object from the storage-cluster
 %%
 -spec(get(binary()) ->
-             {ok, #?METADATA{}, binary(), binary()}|{error, any()}).
+             {ok, #?METADATA{}, binary()}|{error, any()}).
 get(Key) ->
     ok = leo_metrics_req:notify(?STAT_COUNT_GET),
     ReqParams = get_request_parameters(get, Key),
@@ -79,7 +79,7 @@ get(Key) ->
            [ReqParams#rpc_params.addr_id, Key, ReqParams#rpc_params.req_id],
            []).
 -spec(get(binary(), integer()) ->
-             {ok, match}|{ok, #?METADATA{}, binary(), binary()}|{error, any()}).
+             {ok, match}|{ok, #?METADATA{}, binary()}|{error, any()}).
 get(Key, ETag) ->
     ok = leo_metrics_req:notify(?STAT_COUNT_GET),
     ReqParams = get_request_parameters(get, Key),
@@ -90,7 +90,7 @@ get(Key, ETag) ->
            []).
 
 -spec(get(binary(), integer(), integer()) ->
-             {ok, #?METADATA{}, binary(), binary()}|{error, any()}).
+             {ok, #?METADATA{}, binary()}|{error, any()}).
 get(Key, StartPos, EndPos) ->
     ok = leo_metrics_req:notify(?STAT_COUNT_GET),
     ReqParams = get_request_parameters(get, Key),
@@ -219,13 +219,10 @@ invoke([#redundant_node{node = Node,
         %% put
         {value, {ok, {etag, ETag}}} ->
             {ok, ETag};
-        %% get-1: leo_storage's ver is from 1.0 to.1.3.0
-        {value, {ok,_Meta,_Bin}} ->
-            {ok,_Meta,_Bin,<<>>};
-        %% get-2: leo_storage's ver is from 1.3.1
-        {value, {ok,_Meta,_Bin,_CMeta} = Ret} ->
+        %% get-1
+        {value, {ok,_Meta,_Bin} = Ret} ->
             Ret;
-        %% get-3
+        %% get-2
         {value, {ok, match} = Ret} ->
             Ret;
         %% head/get_dir_meta

--- a/test/leo_gateway_rpc_handler_tests.erl
+++ b/test/leo_gateway_rpc_handler_tests.erl
@@ -177,24 +177,26 @@ get_object_error_([_Node0, Node1]) ->
 
 get_object_normal1_([_Node0, Node1]) ->
     ok = rpc:call(Node1, meck, new,    [leo_storage_handler_object, [no_link, non_strict]]),
+    CMetaBin = term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}]),
     ok = rpc:call(Node1, meck, expect, [leo_storage_handler_object, get,
                                         fun(_Addr, Key, _ReqId) ->
                                                 {ok,
                                                  #?METADATA{
                                                      key = Key,
+                                                     meta = CMetaBin,
+                                                     msize = byte_size(CMetaBin),
                                                      dsize = 4,
                                                      del = 0
                                                     },
-                                                 <<"body">>,
-                                                 term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}])
+                                                 <<"body">>
                                                 }
                                         end]),
     KEY = <<"bucket/key">>,
-    {ok, Meta, Body, CMetaBin} = leo_gateway_rpc_handler:get(KEY),
+    {ok, Meta, Body} = leo_gateway_rpc_handler:get(KEY),
     ?assertEqual(4, Meta#?METADATA.dsize),
     ?assertEqual(KEY, Meta#?METADATA.key),
     ?assertEqual(<<"body">>, Body),
-    ?assertEqual(term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}]), CMetaBin),
+    ?assertEqual(term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}]), Meta#?METADATA.meta),
     ok = rpc:call(Node1, meck, unload, [leo_storage_handler_object]),
     ok.
 
@@ -228,24 +230,26 @@ get_object_with_etag_error_([_Node0, Node1]) ->
 
 get_object_with_etag_normal1_([_Node0, Node1]) ->
     ok = rpc:call(Node1, meck, new,    [leo_storage_handler_object, [no_link, non_strict]]),
+    CMetaBin = term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}]),
     ok = rpc:call(Node1, meck, expect, [leo_storage_handler_object, get,
                                         fun(_Addr, Key, _Etag, _ReqId) ->
                                                 {ok,
                                                  #?METADATA{
                                                      key = Key,
+                                                     meta = CMetaBin,
+                                                     msize = byte_size(CMetaBin),
                                                      dsize = 4,
                                                      del = 0
                                                     },
-                                                 <<"body">>,
-                                                 term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}])
+                                                 <<"body">>
                                                 }
                                         end]),
     KEY = <<"bucket/key">>,
-    {ok, Meta, Body, CMetaBin} = leo_gateway_rpc_handler:get(KEY, 123),
+    {ok, Meta, Body} = leo_gateway_rpc_handler:get(KEY, 123),
     ?assertEqual(4, Meta#?METADATA.dsize),
     ?assertEqual(KEY, Meta#?METADATA.key),
     ?assertEqual(<<"body">>, Body),
-    ?assertEqual(term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}]), CMetaBin),
+    ?assertEqual(term_to_binary([{<<"x-amz-meta-test">>, <<"cmeta">>}]), Meta#?METADATA.meta),
     ok = rpc:call(Node1, meck, unload, [leo_storage_handler_object]),
     ok.
 


### PR DESCRIPTION
## Description
1. Roll back of leo_storage API
2. Add Custom Metadata Size Limit
3. Fix for `x-amz-meta-*` pattern matching

## Related Issue
https://github.com/leo-project/leofs/issues/107