### PR TITLE
Fix Recursive Find Ordering

### DIFF
--- a/src/leo_gateway_s3_api.erl
+++ b/src/leo_gateway_s3_api.erl
@@ -2102,7 +2102,7 @@ recursive_find(BucketName, Redundancies, Acc,
                                         [Key, ?BIN_SLASH, Marker, MaxKeys],
                                         []) of
         {ok, Metadata} when is_list(Metadata) ->
-            recursive_find(BucketName, Redundancies, [Metadata | Acc], Rest,
+            recursive_find(BucketName, Redundancies, [Rest | Acc], Metadata,
                            Marker, MaxKeys, LastKey, Transport, Socket);
         {ok,_} ->
             {error, invalid_format};


### PR DESCRIPTION
## Description
Currently the recursive find is in BFS not DFS, therefore the ordering is incorrect.
Next Marker is also incorrect as a result

## Related Issue
https://github.com/leo-project/leofs/issues/558