### PR TITLE
Fix large object put handler for error cases

### DIFF
--- a/src/leo_gateway_http_commons.erl
+++ b/src/leo_gateway_http_commons.erl
@@ -781,9 +781,11 @@ put_large_object(Req, Key, Size, #req_params{bucket_name = BucketName,
                                                    transfer_decode_state = TransferDecodeState}) of
                 {error, ErrorRet} ->
                     ok = leo_large_object_put_handler:rollback(Handler),
-                    {Req_1, Cause} = case (erlang:size(ErrorRet) == 2) of
-                                         true  -> ErrorRet;
-                                         false -> {Req, ErrorRet}
+                    {Req_1, Cause} = case ErrorRet of
+                                         {_, _} ->
+                                             ErrorRet;
+                                         _ ->
+                                             {Req, ErrorRet}
                                      end,
                     reply_fun({error, Cause}, put, BucketName, Key, Size, Req_1, BeginTime);
                 Ret ->

--- a/src/leo_large_object_put_handler.erl
+++ b/src/leo_large_object_put_handler.erl
@@ -293,7 +293,7 @@ send_object(PutReq, BeginTime) ->
     case leo_pod:checkout(?POD_LOH_WORKER) of
         {ok, Worker} ->
             Fun = fun() ->
-                          Ret = gen_server:call(Worker, {put, PutReq}),
+                          Ret = (catch gen_server:call(Worker, {put, PutReq})),
                           ok = leo_pod:checkin(?POD_LOH_WORKER, Worker),
                           erlang:send(self(), {async_notify, Key, Ret})
                   end,


### PR DESCRIPTION
## Related Issue
https://github.com/leo-project/leofs/issues/564

## Observation Before/After
```
~/s3cmd-1.6.1$ parallel -P 16 "./s3cmd put /dev/shm/testfile_0 s3://test/{} &>> log/put{}.log" ::: $(seq 1 256)
```
![large_object_halt](https://cloud.githubusercontent.com/assets/360884/21632930/519acc58-d28e-11e6-93af-0cdf6d28fe19.png)

**Interpretation**
1. High bumps come from s3cmd calculating md5sum of the ~1GB file
2. low bumps with 30-second interval comes from timeout

![grafana_after](https://cloud.githubusercontent.com/assets/360884/21633022/f252e61c-d28e-11e6-86e4-b20a708518e8.png)
